### PR TITLE
Gateway: listen for beeps from clients

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -264,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gateway"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -11,10 +11,8 @@ RUN apt-get install -y clang
 RUN curl -O https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
 
 RUN chmod 755 wait-for-it.sh
-RUN echo "hello.;"
 RUN git fetch && git pull
-RUN git checkout tinker/expiry
 RUN git rev-parse HEAD
 
-#RUN cargo install --path .
-CMD ["sh", "no_run.sh"]
+RUN cargo install --path .
+CMD ["sh", "run.sh"]

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get install -y clang
 RUN curl -O https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
 
 RUN chmod 755 wait-for-it.sh
-RUN echo "hello;"
+RUN echo "hello.;"
 RUN git fetch && git pull
-RUN git checkout tinker/uberlog
+RUN git checkout tinker/expiry
 RUN git rev-parse HEAD
 
 #RUN cargo install --path .

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -11,9 +11,10 @@ RUN apt-get install -y clang
 RUN curl -O https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
 
 RUN chmod 755 wait-for-it.sh
-
+RUN echo "hello;"
 RUN git fetch && git pull
+RUN git checkout tinker/uberlog
 RUN git rev-parse HEAD
 
-RUN cargo install --path .
-CMD ["sh", "run.sh"]
+#RUN cargo install --path .
+CMD ["sh", "no_run.sh"]

--- a/gateway/dev.sh
+++ b/gateway/dev.sh
@@ -3,4 +3,7 @@
 # Cheater script.  Use from inside the docker
 # container, to reduce incremental build times
 
-git fetch && git pull && cargo install --path . --force && gateway
+git fetch && git pull 
+git rev-parse HEAD
+cargo install --path . --force 
+gateway

--- a/gateway/dev.sh
+++ b/gateway/dev.sh
@@ -4,6 +4,5 @@
 # container, to reduce incremental build times
 
 git fetch && git pull 
-git rev-parse HEAD
 cargo install --path . --force 
 gateway

--- a/gateway/src/kafka.rs
+++ b/gateway/src/kafka.rs
@@ -42,7 +42,8 @@ fn start_producer(kafka_out: crossbeam::Receiver<Commands>) {
                             .key(&c.game_id.to_string()), 0);
                         // Fire and forget
                         ()
-                    }       ,
+                    },
+                    Ok(Commands::Beep) => (),
                     Err(e) => panic!("Unable to receive command via kafka channel: {:?}", e),
                 }
         }

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -34,6 +34,7 @@ pub struct MakeMoveCommand {
 #[serde(tag = "type")]
 pub enum Commands {
     MakeMove(MakeMoveCommand),
+    Beep,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -103,12 +104,12 @@ mod tests {
         let req_id = Uuid::new_v4();
 
         assert_eq!(
-            serde_json::to_string(&super::Commands::MakeMove {
+            serde_json::to_string(&super::Commands::MakeMove (super::MakeMoveCommand{
                 game_id,
                 req_id,
                 player: super::Player::BLACK,
                 coord: Some(super::Coord { x: 0, y: 0 })
-            })
+            }))
             .unwrap(),
             format!("{{\"type\":\"MakeMove\",\"gameId\":\"{:?}\",\"reqId\":\"{:?}\",\"player\":\"BLACK\",\"coord\":{{\"x\":0,\"y\":0}}}}", game_id, req_id)
         )

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -78,7 +78,6 @@ impl Handler for WsSession {
     }
 
     fn on_message(&mut self, msg: Message) -> Result<()> {
-        println!("{} RECV {}", short_uuid(self.client_id), msg);
         let deserialized: Result<Commands> = serde_json::from_str(&msg.into_text()?)
             .map_err(|_err| ws::Error::new(ws::ErrorKind::Internal, "json"));
         match deserialized {
@@ -88,6 +87,13 @@ impl Handler for WsSession {
                 player,
                 coord,
             })) => {
+                println!(
+                    "{} MAKE MOVE {} {:?} {:?}",
+                    short_uuid(self.client_id),
+                    short_uuid(game_id),
+                    player,
+                    coord
+                );
                 // For now, set the current game id to
                 // the first one that we try to send a
                 // command to
@@ -129,11 +135,11 @@ impl Handler for WsSession {
                 Ok(())
             }
             Ok(Commands::Beep) => {
-                println!("{} BEEP", short_uuid(self.client_id));
+                println!("{} BEEP ", short_uuid(self.client_id));
                 Ok(())
             }
             Err(e) => {
-                println!("Error deserializing {:?}", e);
+                println!("{} ERROR deserializing {:?}", short_uuid(self.client_id), e);
                 Ok(())
             }
         }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -129,7 +129,7 @@ impl Handler for WsSession {
                 Ok(())
             }
             Ok(Commands::Beep) => {
-                println!("beep from {}", short_uuid(self.client_id));
+                println!("{} BEEP", short_uuid(self.client_id));
                 Ok(())
             }
             Err(e) => {

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -78,8 +78,6 @@ impl Handler for WsSession {
     }
 
     fn on_message(&mut self, msg: Message) -> Result<()> {
-
-
         println!("{} got message '{}' ", short_uuid(self.client_id), msg);
         let deserialized: Result<Commands> = serde_json::from_str(&msg.into_text()?)
             .map_err(|_err| ws::Error::new(ws::ErrorKind::Internal, "json"));
@@ -130,6 +128,10 @@ impl Handler for WsSession {
 
                 Ok(())
             }
+            Ok(Commands::Beep) => {
+                println!("beep from {}", short_uuid(self.client_id));
+                Ok(())
+            }
             Err(e) => {
                 println!("Error deserializing {:?}", e);
                 Ok(())
@@ -138,7 +140,12 @@ impl Handler for WsSession {
     }
 
     fn on_close(&mut self, code: CloseCode, reason: &str) {
-        println!("{} closing ({:?}) {}", short_uuid(self.client_id), code, reason);
+        println!(
+            "{} closing ({:?}) {}",
+            short_uuid(self.client_id),
+            code,
+            reason
+        );
 
         self.notify_router_close();
 
@@ -220,7 +227,11 @@ impl Handler for WsSession {
         if frame.opcode() == OpCode::Pong {
             if let Ok(pong) = from_utf8(frame.payload())?.parse::<u64>() {
                 let now = time::precise_time_ns();
-                println!("{} ping RTT: {:.3}ms", short_uuid(self.client_id), (now - pong) as f64 / 1_000_000f64);
+                println!(
+                    "{} PONG ({:.3}ms)",
+                    short_uuid(self.client_id),
+                    (now - pong) as f64 / 1_000_000f64
+                );
             } else {
                 println!("Received bad pong.");
             }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -88,7 +88,7 @@ impl Handler for WsSession {
                 coord,
             })) => {
                 println!(
-                    "{} MAKE MOVE {} {:?} {:?}",
+                    "{} MOVE {} {:?} {:?}",
                     short_uuid(self.client_id),
                     short_uuid(game_id),
                     player,

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -78,7 +78,7 @@ impl Handler for WsSession {
     }
 
     fn on_message(&mut self, msg: Message) -> Result<()> {
-        println!("{} MESSAGE {}", short_uuid(self.client_id), msg);
+        println!("{} RECV {}", short_uuid(self.client_id), msg);
         let deserialized: Result<Commands> = serde_json::from_str(&msg.into_text()?)
             .map_err(|_err| ws::Error::new(ws::ErrorKind::Internal, "json"));
         match deserialized {

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -222,6 +222,8 @@ impl Handler for WsSession {
         }
 
         // Some activity has occured, so reset the expiration
+        println!("Reset EXPIRE");
+        self.expire_timeout.take();
         self.ws_out.timeout(EXPIRE_TIMEOUT_MS, EXPIRE)?;
 
         // Run default frame validation

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -78,7 +78,7 @@ impl Handler for WsSession {
     }
 
     fn on_message(&mut self, msg: Message) -> Result<()> {
-        println!("{} got message '{}' ", short_uuid(self.client_id), msg);
+        println!("{} MESSAGE {}", short_uuid(self.client_id), msg);
         let deserialized: Result<Commands> = serde_json::from_str(&msg.into_text()?)
             .map_err(|_err| ws::Error::new(ws::ErrorKind::Internal, "json"));
         match deserialized {
@@ -141,7 +141,7 @@ impl Handler for WsSession {
 
     fn on_close(&mut self, code: CloseCode, reason: &str) {
         println!(
-            "{} closing ({:?}) {}",
+            "{} CLOSING ({:?}) {}",
             short_uuid(self.client_id),
             code,
             reason
@@ -235,8 +235,6 @@ impl Handler for WsSession {
             } else {
                 println!("Received bad pong.");
             }
-        } else {
-            println!("Frame opcode {}", frame.opcode())
         }
 
         // Some activity has occured, so reset the expiration

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -21,8 +21,6 @@ const PING_TIMEOUT_MS: u64 = 5_000;
 const EXPIRE_TIMEOUT_MS: u64 = 15_000;
 const CHANNEL_RECV_TIMEOUT_MS: u64 = 10;
 
-const PRINT_PINGS_BEEPS: bool = false;
-
 // WebSocket handler
 pub struct WsSession {
     pub client_id: ClientId,
@@ -139,9 +137,8 @@ impl Handler for WsSession {
                 Ok(())
             }
             Ok(Commands::Beep) => {
-                if PRINT_PINGS_BEEPS {
-                    println!("{} BEEP  ", short_uuid(self.client_id));
-                }
+                println!("{} BEEP  ", short_uuid(self.client_id));
+
                 Ok(())
             }
             Err(e) => {
@@ -239,13 +236,11 @@ impl Handler for WsSession {
         if frame.opcode() == OpCode::Pong {
             if let Ok(pong) = from_utf8(frame.payload())?.parse::<u64>() {
                 let now = time::precise_time_ns();
-                if PRINT_PINGS_BEEPS {
-                    println!(
-                        "{} PONG ({:.3}ms)",
-                        short_uuid(self.client_id),
-                        (now - pong) as f64 / 1_000_000f64
-                    );
-                }
+                println!(
+                    "{} PONG ({:.3}ms)",
+                    short_uuid(self.client_id),
+                    (now - pong) as f64 / 1_000_000f64
+                );
             } else {
                 println!("Received bad pong.");
             }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -224,6 +224,8 @@ impl Handler for WsSession {
             } else {
                 println!("Received bad pong.");
             }
+        } else {
+            println!("Frame opcode {}", frame.opcode())
         }
 
         // Some activity has occured, so reset the expiration

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -76,6 +76,8 @@ impl Handler for WsSession {
     }
 
     fn on_message(&mut self, msg: Message) -> Result<()> {
+
+
         println!("WsSession got message '{}'. ", msg);
         let deserialized: Result<Commands> = serde_json::from_str(&msg.into_text()?)
             .map_err(|_err| ws::Error::new(ws::ErrorKind::Internal, "json"));
@@ -195,7 +197,7 @@ impl Handler for WsSession {
             }
             self.expire_timeout = Some(timeout)
         } else if event == PING {
-            // This ensures there is only one ping timeout at a time
+            // This ensures there is only one timeout at a time
             if let Some(t) = self.ping_timeout.take() {
                 self.ws_out.cancel(t)?
             }
@@ -204,6 +206,7 @@ impl Handler for WsSession {
             if let Some(t) = self.channel_recv_timeout.take() {
                 self.ws_out.cancel(t)?
             }
+            self.channel_recv_timeout = Some(timeout)
         }
 
         Ok(())
@@ -222,8 +225,6 @@ impl Handler for WsSession {
         }
 
         // Some activity has occured, so reset the expiration
-        println!("Reset EXPIRE");
-        self.expire_timeout.take();
         self.ws_out.timeout(EXPIRE_TIMEOUT_MS, EXPIRE)?;
 
         // Run default frame validation

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -16,7 +16,7 @@ const EXPIRE: Token = Token(2);
 const CHANNEL_RECV: Token = Token(3);
 
 const PING_TIMEOUT_MS: u64 = 5_000;
-const EXPIRE_TIMEOUT_MS: u64 = 30_000;
+const EXPIRE_TIMEOUT_MS: u64 = 15_000;
 const CHANNEL_RECV_TIMEOUT_MS: u64 = 10;
 
 // WebSocket handler

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -18,7 +18,7 @@ const EXPIRE: Token = Token(2);
 const CHANNEL_RECV: Token = Token(3);
 
 const PING_TIMEOUT_MS: u64 = 5_000;
-const EXPIRE_TIMEOUT_MS: u64 = 15_000;
+const EXPIRE_TIMEOUT_MS: u64 = 55_000;
 const CHANNEL_RECV_TIMEOUT_MS: u64 = 10;
 
 // WebSocket handler

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -170,6 +170,7 @@ impl Handler for WsSession {
             // EXPIRE timeout has occured, this means that the connection is inactive, let's close
             EXPIRE => {
                 self.notify_router_close();
+                println!("{} closing: away", self.client_id);
                 self.ws_out.close(CloseCode::Away)
             }
             CHANNEL_RECV => {
@@ -218,7 +219,7 @@ impl Handler for WsSession {
         if frame.opcode() == OpCode::Pong {
             if let Ok(pong) = from_utf8(frame.payload())?.parse::<u64>() {
                 let now = time::precise_time_ns();
-                println!("RTT is {:.3}ms.", (now - pong) as f64 / 1_000_000f64);
+                println!("{} ping RTT: {:.3}ms", self.client_id, (now - pong) as f64 / 1_000_000f64);
             } else {
                 println!("Received bad pong.");
             }


### PR DESCRIPTION
Adds support for a `{"type": "Beep"}` command to the gateway component. This helps prevent disconnection.

Cleans up log messages, fixes a test, and raises socket expiry time.