### PR TITLE
Gateway: allow websocket reconnect

### DIFF
--- a/dit-gateway.sh
+++ b/dit-gateway.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker exec -it `docker ps|grep gateway|awk '{print $1;}'` bash

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -264,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gateway"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -15,4 +15,7 @@ RUN git fetch && git pull
 RUN git rev-parse HEAD
 
 RUN cargo install --path .
-CMD ["sh", "run.sh"]
+#TODO
+RUN git fetch && git checkout feature/websocket-reconnect
+#TODO
+CMD ["sh", "no_run.sh"]

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -15,7 +15,4 @@ RUN git fetch && git pull
 RUN git rev-parse HEAD
 
 RUN cargo install --path .
-#TODO
-RUN git fetch && git checkout feature/websocket-reconnect
-#TODO
-CMD ["sh", "no_run.sh"]
+CMD ["sh", "run.sh"]

--- a/gateway/src/kafka.rs
+++ b/gateway/src/kafka.rs
@@ -20,7 +20,7 @@ const GAME_STATES_TOPIC: &str = "bugout-game-states";
 const MAKE_MOVE_CMD_TOPIC: &str = "bugout-make-move-cmd";
 const MOVE_MADE_EV_TOPIC: &str = "bugout-move-made-ev";
 const CONSUME_TOPICS: &[&str] = &[MOVE_MADE_EV_TOPIC];
-const NUM_PREMADE_GAMES: usize = 32;
+const NUM_PREMADE_GAMES: usize = 64;
 
 pub fn start(
     events_in: crossbeam::Sender<Events>,

--- a/gateway/src/kafka.rs
+++ b/gateway/src/kafka.rs
@@ -25,7 +25,7 @@ const NUM_PREMADE_GAMES: usize = 32;
 pub fn start(
     events_in: crossbeam::Sender<Events>,
     router_commands_in: crossbeam::Sender<RouterCommand>,
-    commands_out: crossbeam::Receiver<Commands>,
+    commands_out: crossbeam::Receiver<ClientCommands>,
 ) {
     thread::spawn(move || start_producer(router_commands_in, commands_out));
 
@@ -34,7 +34,7 @@ pub fn start(
 
 fn start_producer(
     router_commands_in: crossbeam::Sender<RouterCommand>,
-    kafka_out: crossbeam::Receiver<Commands>,
+    kafka_out: crossbeam::Receiver<ClientCommands>,
 ) {
     let producer = configure_producer(BROKERS);
 
@@ -44,7 +44,7 @@ fn start_producer(
         select! {
             recv(kafka_out) -> command =>
                 match command {
-                    Ok(Commands::MakeMove(c)) => {
+                    Ok(ClientCommands::MakeMove(c)) => {
                         producer.send(FutureRecord::to(MAKE_MOVE_CMD_TOPIC)
                             .payload(&serde_json::to_string(&c).unwrap())
                             .key(&c.game_id.to_string()), 0);

--- a/gateway/src/logging.rs
+++ b/gateway/src/logging.rs
@@ -28,7 +28,7 @@ pub fn short_time() -> i64 {
 pub fn session_code(ws_session: &WsSession) -> String {
     let empty_short_uuid = "        ";
     format!(
-        "{} {:?}",
+        "{} {}",
         short_uuid(ws_session.client_id),
         ws_session
             .current_game

--- a/gateway/src/logging.rs
+++ b/gateway/src/logging.rs
@@ -2,6 +2,7 @@ use rand::seq::SliceRandom;
 use uuid::Uuid;
 
 use crate::model::Player;
+use crate::websocket::WsSession;
 
 pub fn emoji(player: &Player) -> String {
     match player {
@@ -22,4 +23,17 @@ pub fn short_uuid(uuid: Uuid) -> String {
 
 pub fn short_time() -> i64 {
     time::now_utc().to_timespec().sec % 10_000
+}
+
+pub fn session_code(ws_session: &WsSession) -> String {
+    let empty_short_uuid = "        ";
+    format!(
+        "{} {:?}",
+        short_uuid(ws_session.client_id),
+        ws_session
+            .current_game
+            .map(|gid| short_uuid(gid))
+            .unwrap_or(empty_short_uuid.to_string())
+    )
+    .to_string()
 }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -17,13 +17,15 @@ mod websocket;
 
 use crossbeam_channel::{unbounded, Receiver, Sender};
 
-use model::{Commands, Events};
+use model::{ClientCommands, Events};
 use router::RouterCommand;
 use websocket::WsSession;
 
 fn main() {
-    let (bugout_commands_in, bugout_commands_out): (Sender<Commands>, Receiver<Commands>) =
-        unbounded();
+    let (bugout_commands_in, bugout_commands_out): (
+        Sender<ClientCommands>,
+        Receiver<ClientCommands>,
+    ) = unbounded();
 
     let (kafka_events_in, kafka_events_out): (Sender<Events>, Receiver<Events>) = unbounded();
 

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -20,6 +20,15 @@ pub enum Player {
     WHITE,
 }
 
+impl Player {
+    pub fn other(&self) -> Player {
+        match self {
+            Player::BLACK => Player::WHITE,
+            Player::WHITE => Player::BLACK,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MakeMoveCommand {
     #[serde(rename = "gameId")]

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -46,7 +46,7 @@ pub struct ReconnectCommand {
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
-pub enum Commands {
+pub enum ClientCommands {
     MakeMove(MakeMoveCommand),
     Beep,
     RequestOpenGame(RequestGameIdCommand),
@@ -107,7 +107,10 @@ impl Events {
 }
 
 pub enum BugoutMessage {
-    Command { client_id: Uuid, command: Commands },
+    Command {
+        client_id: Uuid,
+        command: ClientCommands,
+    },
     Event(Events),
 }
 
@@ -132,7 +135,7 @@ mod tests {
         let req_id = Uuid::new_v4();
 
         assert_eq!(
-            serde_json::to_string(&super::Commands::MakeMove (super::MakeMoveCommand{
+            serde_json::to_string(&super::ClientCommands::MakeMove (super::MakeMoveCommand{
                 game_id,
                 req_id,
                 player: super::Player::BLACK,

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -36,12 +36,21 @@ pub struct RequestGameIdCommand {
     pub req_id: ReqId,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReconnectCommand {
+    #[serde(rename = "gameId")]
+    pub game_id: GameId,
+    #[serde(rename = "reqId")]
+    pub req_id: ReqId,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub enum Commands {
     MakeMove(MakeMoveCommand),
     Beep,
     RequestOpenGame(RequestGameIdCommand),
+    Reconnect(ReconnectCommand),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -96,6 +96,8 @@ pub struct ReconnectedEvent {
     pub reply_to: ReqId,
     #[serde(rename = "eventId")]
     pub event_id: EventId,
+    #[serde(rename = "playerUp")]
+    pub player_up: Player,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -89,11 +89,22 @@ pub struct OpenGameReplyEvent {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReconnectedEvent {
+    #[serde(rename = "gameId")]
+    pub game_id: GameId,
+    #[serde(rename = "replyTo")]
+    pub reply_to: ReqId,
+    #[serde(rename = "eventId")]
+    pub event_id: EventId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
 pub enum Events {
     MoveMade(MoveMadeEvent),
     MoveRejected(MoveRejectedEvent),
     OpenGameReply(OpenGameReplyEvent),
+    Reconnected(ReconnectedEvent),
 }
 
 impl Events {
@@ -102,6 +113,7 @@ impl Events {
             Events::MoveMade(e) => e.game_id,
             Events::MoveRejected(e) => e.game_id,
             Events::OpenGameReply(e) => e.game_id,
+            Events::Reconnected(e) => e.game_id,
         }
     }
 }

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -118,14 +118,6 @@ impl Events {
     }
 }
 
-pub enum BugoutMessage {
-    Command {
-        client_id: Uuid,
-        command: ClientCommands,
-    },
-    Event(Events),
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Captures {
     pub black: u16,

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -6,6 +6,7 @@ use crossbeam_channel::select;
 
 use uuid::Uuid;
 
+use crate::logging::short_uuid;
 use crate::model::{ClientId, Events, GameId, OpenGameReplyEvent, ReconnectedEvent, ReqId};
 
 /// start the select! loop responsible for sending kafka messages to relevant websocket clients
@@ -118,7 +119,7 @@ impl Router {
         self.available_games.push(game_id);
         self.available_games.push(game_id);
 
-        println!("📝 Registered open game {}", game_id)
+        println!("📝 OPEN GAME {}", short_uuid(game_id))
     }
 
     fn pop_open_game_id(&mut self) -> GameId {

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -25,7 +25,7 @@ pub fn start(router_commands_out: Receiver<RouterCommand>, kafka_events_out: Rec
                             router.delete_client(client_id, game_id),
                         Ok(RouterCommand::RegisterOpenGame{game_id}) =>
                             router.register_open_game(game_id),
-                        Ok(RouterCommand::Reconnect{client_id, game_id, events_in}) =>
+                        Ok(RouterCommand::Reconnect{client_id, game_id, events_in, req_id }) =>
                             unimplemented!(),
                         Err(e) => panic!("Unable to receive command via router channel: {:?}", e),
                     },
@@ -134,5 +134,6 @@ pub enum RouterCommand {
         client_id: ClientId,
         game_id: GameId,
         events_in: Sender<Events>,
+        req_id: ReqId,
     },
 }

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -83,7 +83,8 @@ impl Router {
 
     // TODO This is never cleaned up
     pub fn set_playerup(&mut self, game_id: GameId, player: Player) {
-        self.playerup_by_game.entry(game_id).or_insert(player);
+        let c = player.clone();
+        *self.playerup_by_game.entry(game_id).or_insert(c) = player;
     }
 
     pub fn add_client(&mut self, client_id: ClientId, events_in: Sender<Events>) -> GameId {

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -119,7 +119,7 @@ impl Router {
         self.available_games.push(game_id);
         self.available_games.push(game_id);
 
-        println!("📝 OPEN GAME {}", short_uuid(game_id))
+        println!("📝 GAME {}", short_uuid(game_id))
     }
 
     fn pop_open_game_id(&mut self) -> GameId {

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -36,7 +36,7 @@ pub fn start(router_commands_out: Receiver<RouterCommand>, kafka_events_out: Rec
                     match event {
                         Ok(Events::MoveMade(m)) => {
                             let u = m.clone();
-                            router.set_playerup(u.game_id, u.player);
+                            router.set_playerup(u.game_id, u.player.other());
                             router.forward_event(Events::MoveMade(m))
                         }
                         Ok(e) =>

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -113,10 +113,7 @@ impl Handler for WsSession {
                 Ok(())
             }
             Ok(ClientCommands::Beep) => {
-                println!(
-                    "🤖 {} BEEP   ",
-                    session_code(self)
-                );
+                println!("🤖 {} BEEP   ", session_code(self));
 
                 Ok(())
             }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -139,6 +139,7 @@ impl Handler for WsSession {
                 Ok(())
             }
             Ok(ClientCommands::Reconnect(ReconnectCommand { game_id, req_id })) => {
+                println!("🔌 {} RECONN ", session_code(self));
                 let (events_in, events_out) = client_event_channels();
 
                 // ..and let the router know we're interested in it,
@@ -154,6 +155,9 @@ impl Handler for WsSession {
 
                 //.. and track the out-channel so we can select! on it
                 self.events_out = Some(events_out);
+
+                // accept whatever game_id the client shares with us
+                self.current_game = Some(game_id);
 
                 Ok(())
             }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -139,6 +139,9 @@ impl Handler for WsSession {
                 Ok(())
             }
             Ok(ClientCommands::Reconnect(ReconnectCommand { game_id, req_id })) => {
+                // accept whatever game_id the client shares with us
+                self.current_game = Some(game_id);
+
                 println!("🔌 {} RECONN ", session_code(self));
                 let (events_in, events_out) = client_event_channels();
 
@@ -155,9 +158,6 @@ impl Handler for WsSession {
 
                 //.. and track the out-channel so we can select! on it
                 self.events_out = Some(events_out);
-
-                // accept whatever game_id the client shares with us
-                self.current_game = Some(game_id);
 
                 Ok(())
             }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -131,7 +131,7 @@ impl Handler for WsSession {
                     // ..and let the router know we're interested in it,
                     // so that we can receive updates
                     self.router_commands_in
-                        .send(RouterCommand::AddClient {
+                        .send(RouterCommand::RequestOpenGame {
                             client_id: self.client_id,
                             events_in,
                             req_id: req.req_id,

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -114,9 +114,8 @@ impl Handler for WsSession {
             }
             Ok(ClientCommands::Beep) => {
                 println!(
-                    "🤖 {} BEEP   {:?}",
-                    session_code(self),
-                    self.current_game.map(|gid| short_uuid(gid))
+                    "🤖 {} BEEP   ",
+                    session_code(self)
                 );
 
                 Ok(())

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -89,7 +89,7 @@ impl Handler for WsSession {
                 coord,
             })) => {
                 println!(
-                    "{} MOVE   {} {:?} {:?}",
+                    "{} {} MOVE   {:?} {:?}",
                     emoji(&player),
                     session_code(self),
                     player,

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -143,6 +143,7 @@ impl Handler for WsSession {
                 }
                 Ok(())
             }
+            Ok(Commands::Reconnect(req)) => unimplemented!(),
             Err(_err) => {
                 println!(
                     "💥 {} ERROR  message deserialization failed",


### PR DESCRIPTION
Resolves #48: clients may reconnect to a game in progress.  For 80% of cases, this results in two different clients being able to continue to send moves back and forth despite websocket disconnects.  

Also allows the gateway router to track the current player color each game. This isn't used yet by the client, but should be helpful for cases where a websocket disconnects and then reconnects expecting the wrong player to move next.