### PR TITLE
Gateway: lower send expectations

### DIFF
--- a/build-all-dc.sh
+++ b/build-all-dc.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+alias docker-compose='docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$PWD:/rootfs/$PWD" \
+  -w="/rootfs/$PWD" \
+docker/compose:1.13.0'
+
 # This script is useful for environments where you
 # do not have access to cargo, gradle etc
 docker-compose build judge

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -264,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gateway"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/gateway/src/logging.rs
+++ b/gateway/src/logging.rs
@@ -17,6 +17,7 @@ pub fn emoji(player: &Player) -> String {
     }
 }
 
+pub const EMPTY_SHORT_UUID: &str = "        ";
 pub fn short_uuid(uuid: Uuid) -> String {
     uuid.to_string()[..8].to_string()
 }
@@ -26,14 +27,13 @@ pub fn short_time() -> i64 {
 }
 
 pub fn session_code(ws_session: &WsSession) -> String {
-    let empty_short_uuid = "        ";
     format!(
         "{} {}",
         short_uuid(ws_session.client_id),
         ws_session
             .current_game
             .map(|gid| short_uuid(gid))
-            .unwrap_or(empty_short_uuid.to_string())
+            .unwrap_or(EMPTY_SHORT_UUID.to_string())
     )
     .to_string()
 }


### PR DESCRIPTION
Removes some unnecessary `expect` statement from channel sends.  We saw these triggered when websockets were closed and couldn't be delivered to.