### PR TITLE
Reorganize Kafka topics to prevent race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 - A [public-facing websocket gateway](gateway/README.md) communicates with the browser
 - [Kotlin & Kafka streams adjudicates games](judge/README.md), [announces moves](changelog/README.md), and [will eventually provide lobby functionality](https://github.com/Terkwood/BUGOUT/issues/42)
 
+## Data Flow
+
+Judge emits move data to `bugout-move-accepted-ev`, which is an input to changelog.  Changelog emits moves to `bugout-move-made-ev` after recording them.  Gateway listens to `bugout-move-made-ev`.
+
 ## Resources
 
 - [Kotlin + Kafka streams](https://blog.ippon.tech/kafka-tutorial-6-kafka-streams-in-kotlin/)

--- a/build-changelog.sh
+++ b/build-changelog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PROJECT="gamestates-aggregator"
+PROJECT="changelog"
 START_DIR=$(pwd)
 
 cd $PROJECT && sh build.sh && cd .. && docker-compose build $PROJECT

--- a/changelog/build.sh
+++ b/changelog/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PROJ_NAME="bugout.gamestates.aggregator"
+PROJ_NAME="bugout.changelog"
 
 rm -f ./build/libs/$PROJ_NAME*.jar
 gradle build

--- a/changelog/src/main/kotlin/Aggregator.kt
+++ b/changelog/src/main/kotlin/Aggregator.kt
@@ -5,7 +5,6 @@ import org.apache.kafka.streams.KeyValue
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.kstream.*
 import org.apache.kafka.streams.state.KeyValueStore
-import org.apache.kafka.streams.state.QueryableStoreTypes
 import serdes.GameStateDeserializer
 import serdes.GameStateSerializer
 import serdes.jsonMapper
@@ -20,7 +19,7 @@ class Aggregator(private val brokers: String) {
 
         val streamsBuilder = StreamsBuilder()
         val moveMadeEventJsonStream = streamsBuilder.stream<UUID, String>(
-            MOVE_MADE_EV_TOPIC,
+            MOVE_ACCEPTED_EV_TOPIC,
             Consumed.with(Serdes.UUID(), Serdes.String())
         )
 

--- a/changelog/src/main/kotlin/Aggregator.kt
+++ b/changelog/src/main/kotlin/Aggregator.kt
@@ -36,7 +36,7 @@ class Aggregator(private val brokers: String) {
                     list.add(
                         jsonMapper.readValue(
                             v,
-                            MoveMadeEv::class.java
+                            MoveEv::class.java
                         )
                     )
                     list
@@ -64,6 +64,13 @@ class Aggregator(private val brokers: String) {
                 Produced.with(Serdes.UUID(), Serdes.String())
             )
 
+        gameStates
+            .toStream()
+            .filter { _, v ->
+                v.moves.isNotEmpty()
+            }
+            .mapValues { v -> v.moves.last() }
+            .to(MOVE_MADE_EV_TOPIC)
 
         val topology = streamsBuilder.build()
 

--- a/changelog/src/main/kotlin/Aggregator.kt
+++ b/changelog/src/main/kotlin/Aggregator.kt
@@ -70,7 +70,9 @@ class Aggregator(private val brokers: String) {
                 v.moves.isNotEmpty()
             }
             .mapValues { v -> v.moves.last() }
-            .to(MOVE_MADE_EV_TOPIC)
+            .mapValues { v -> jsonMapper.writeValueAsString(v) }
+            .to(MOVE_MADE_EV_TOPIC,
+                Produced.with(Serdes.UUID(), Serdes.String()))
 
         val topology = streamsBuilder.build()
 

--- a/changelog/src/main/kotlin/Aggregator.kt
+++ b/changelog/src/main/kotlin/Aggregator.kt
@@ -57,7 +57,7 @@ class Aggregator(private val brokers: String) {
         gameStates
             .toStream()
             .map { k, v ->
-                println("changelog   ${k?.toString()?.take(8)}: Turn ${v.turn} PlayerUp: ${v.playerUp} Pieces: ${v.board.pieces.size} ")
+                println("\uD83D\uDCBE          ${k?.toString()?.take(8)} AGGRGATE Turn ${v.turn} PlayerUp: ${v.playerUp} Pieces: ${v.board.pieces.size} ")
                 KeyValue(k,jsonMapper.writeValueAsString(v))
             }.to(
                 GAME_STATES_CHANGELOG_TOPIC,

--- a/changelog/src/main/kotlin/Aggregator.kt
+++ b/changelog/src/main/kotlin/Aggregator.kt
@@ -57,7 +57,7 @@ class Aggregator(private val brokers: String) {
         gameStates
             .toStream()
             .map { k, v ->
-                println("\uD83D\uDCBE          ${k?.toString()?.take(8)} AGGRGATE Turn ${v.turn} PlayerUp: ${v.playerUp} Pieces: ${v.board.pieces.size} ")
+                println("\uD83D\uDCBE          ${k?.toString()?.take(8)} AGGRGATE Turn ${v.turn} PlayerUp ${v.playerUp}")
                 KeyValue(k,jsonMapper.writeValueAsString(v))
             }.to(
                 GAME_STATES_CHANGELOG_TOPIC,

--- a/changelog/src/main/kotlin/GameState.kt
+++ b/changelog/src/main/kotlin/GameState.kt
@@ -12,7 +12,11 @@ class GameState(boardSize: Int = FULL_BOARD_SIZE) {
 
     var playerUp: Player = Player.BLACK
 
-    fun add(ev: MoveMadeEv): GameState {
+    val moves: MutableList<MoveEv> = mutableListOf()
+
+    fun add(ev: MoveEv): GameState {
+        moves.add(ev)
+
         if (ev.coord != null) {
             board.pieces[ev.coord] = ev.player
             ev.captured.forEach { coord ->

--- a/changelog/src/main/kotlin/Model.kt
+++ b/changelog/src/main/kotlin/Model.kt
@@ -19,7 +19,8 @@ typealias GameId = UUID
 typealias RequestId = UUID
 typealias EventId = UUID
 
-data class MoveMadeEv(
+/// Either a MoveAccepted or a MoveMade
+data class MoveEv(
     val gameId: GameId,
     val replyTo: RequestId,
     val eventId: EventId = UUID.randomUUID(),

--- a/changelog/src/main/kotlin/Topics.kt
+++ b/changelog/src/main/kotlin/Topics.kt
@@ -1,3 +1,3 @@
-const val MOVE_MADE_EV_TOPIC = "bugout-move-made-ev"
+const val MOVE_ACCEPTED_EV_TOPIC = "bugout-move-accepted-ev"
 const val GAME_STATES_STORE_NAME = "bugout-game-states-store"
 const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"

--- a/changelog/src/main/kotlin/Topics.kt
+++ b/changelog/src/main/kotlin/Topics.kt
@@ -1,3 +1,4 @@
 const val MOVE_ACCEPTED_EV_TOPIC = "bugout-move-accepted-ev"
+const val MOVE_MADE_EV_TOPIC = "bugout-move-made-ev"
 const val GAME_STATES_STORE_NAME = "bugout-game-states-store"
 const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_CREATE_TOPICS: "bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1"
+      KAFKA_CREATE_TOPICS: "bugout-move-allowed-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_CREATE_TOPICS: "bugout-move-allowed-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1"
+      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/judge/src/main/kotlin/Constants.kt
+++ b/judge/src/main/kotlin/Constants.kt
@@ -1,7 +1,7 @@
 const val FULL_BOARD_SIZE = 19
 
 const val MAKE_MOVE_CMD_TOPIC = "bugout-make-move-cmd"
-const val MOVE_MADE_EV_TOPIC = "bugout-move-made-ev"
+const val MOVE_ACCEPTED_EV_TOPIC = "bugout-move-accepted-ev"
 const val MOVE_REJECTED_EV_TOPIC = "bugout-move-rejected-ev"
 const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"
 const val GAME_STATES_STORE = "bugout-game-states-store-judge"

--- a/judge/src/main/kotlin/GameState.kt
+++ b/judge/src/main/kotlin/GameState.kt
@@ -4,7 +4,8 @@ data class GameState(
     val board: Board = Board(),
     val captures: Captures = Captures(),
     val turn: Int = 1,
-    val playerUp: Player = Player.BLACK
+    val playerUp: Player = Player.BLACK,
+    val moves: List<MoveAcceptedEv> = listOf()
 ) {
 
     fun asByteArray(): ByteArray {

--- a/judge/src/main/kotlin/Judge.kt
+++ b/judge/src/main/kotlin/Judge.kt
@@ -31,7 +31,7 @@ class Judge(private val brokers: String) {
                 jsonMapper.readValue(v, MakeMoveCmd::class.java)
             }.mapValues { v ->
                 println(
-                    "MAKE MOVE CMD ${v.gameId.short()} ${v
+                    "\uD83D\uDCE2          ${v.gameId.short()} MOVE     ${v
                         .player} ${v
                         .coord}"
                 )
@@ -104,7 +104,7 @@ class Judge(private val brokers: String) {
 
         validMoveAcceptedStream.mapValues { v ->
             println(
-                "\uD83D\uDC69\u200D          ️${v.gameId.short()} ACCEPT   ${v
+                "⚖️          ️${v.gameId.short()} ACCEPT   ${v
                     .player} @ ${v
                     .coord} capturing ${v.captured.joinToString(",")}"
             )

--- a/judge/src/main/kotlin/Judge.kt
+++ b/judge/src/main/kotlin/Judge.kt
@@ -85,8 +85,7 @@ class Judge(private val brokers: String) {
 
         val validMoveGameState = branches[0]
 
-        // TODO rename
-        val validMoveMadeEventStream: KStream<GameId, MoveAcceptedEv> =
+        val validMoveAcceptedStream: KStream<GameId, MoveAcceptedEv> =
             validMoveGameState.map { _, moveCmdGameState ->
                 val eventId = UUID.randomUUID()
                 val move = moveCmdGameState.moveCmd
@@ -107,7 +106,7 @@ class Judge(private val brokers: String) {
                 )
             }
 
-        validMoveMadeEventStream.mapValues { v ->
+        validMoveAcceptedStream.mapValues { v ->
             println(
                 "move made ${v.gameId.short()}: ${v.player} @ ${v
                     .coord} capturing ${v.captured.joinToString(",")}"

--- a/judge/src/main/kotlin/Judge.kt
+++ b/judge/src/main/kotlin/Judge.kt
@@ -113,7 +113,7 @@ class Judge(private val brokers: String) {
             )
             jsonMapper.writeValueAsString(v)
         }.to(
-            MOVE_MADE_EV_TOPIC,
+            MOVE_ACCEPTED_EV_TOPIC,
             Produced.with(Serdes.UUID(), Serdes.String())
         )
 

--- a/judge/src/main/kotlin/Judge.kt
+++ b/judge/src/main/kotlin/Judge.kt
@@ -85,7 +85,8 @@ class Judge(private val brokers: String) {
 
         val validMoveGameState = branches[0]
 
-        val validMoveMadeEventStream: KStream<GameId, MoveMadeEv> =
+        // TODO rename
+        val validMoveMadeEventStream: KStream<GameId, MoveAcceptedEv> =
             validMoveGameState.map { _, moveCmdGameState ->
                 val eventId = UUID.randomUUID()
                 val move = moveCmdGameState.moveCmd
@@ -95,7 +96,7 @@ class Judge(private val brokers: String) {
                 } else listOf()
                 KeyValue(
                     move.gameId,
-                    MoveMadeEv(
+                    MoveAcceptedEv(
                         gameId = move.gameId,
                         replyTo = move.reqId,
                         eventId = eventId,

--- a/judge/src/main/kotlin/Judge.kt
+++ b/judge/src/main/kotlin/Judge.kt
@@ -76,10 +76,6 @@ class Judge(private val brokers: String) {
                 valueJoiner
             )
 
-        makeMoveCommandGameStates.mapValues { v ->
-            println("oh hey ${v.moveCmd.gameId} turn ${v.gameState.turn}")
-        }
-
         val branches = makeMoveCommandGameStates
             .kbranch({ _, moveGameState -> moveGameState.isValid() })
 
@@ -108,7 +104,8 @@ class Judge(private val brokers: String) {
 
         validMoveAcceptedStream.mapValues { v ->
             println(
-                "move made ${v.gameId.short()}: ${v.player} @ ${v
+                "\uD83D\uDC69\u200D          ️${v.gameId.short()} ACCEPT   ${v
+                    .player} @ ${v
                     .coord} capturing ${v.captured.joinToString(",")}"
             )
             jsonMapper.writeValueAsString(v)

--- a/judge/src/main/kotlin/Model.kt
+++ b/judge/src/main/kotlin/Model.kt
@@ -25,7 +25,7 @@ data class MakeMoveCmd(
     val coord: Coord?
 )
 
-data class MoveMadeEv(
+data class MoveAcceptedEv(
     val gameId: GameId,
     val replyTo: RequestId,
     val eventId: EventId = UUID.randomUUID(),


### PR DESCRIPTION
Resolves #58, preventing the clients from racing against changelog's game state aggregation

Judge now emits move data to `bugout-move-accepted-ev`, which is an input to changelog.  Changelog emits moves to `bugout-move-made-ev` after recording them.  Gateway still listens to `bugout-move-made-ev`, as before.

Fixes gradle shell scripts

## TODO
- [x] FIX UP NAMES 