### PR TITLE
📣 Gateway: add KafkaCommands, trim ClientCommands

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -271,7 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gateway"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/gateway/examples/history.rs
+++ b/gateway/examples/history.rs
@@ -58,7 +58,7 @@ fn main() {
         |recv_msg| {
             // Handle messages received on this connection
             println!("Client got message {} ", recv_msg);
-            
+
             Ok(())
         }
     }) {

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -19,7 +19,7 @@ mod websocket;
 
 use crossbeam_channel::{unbounded, Receiver, Sender};
 
-use model::{ClientCommands, Events};
+use model::{Events, KafkaCommands};
 use router::RouterCommand;
 use websocket::WsSession;
 
@@ -29,9 +29,9 @@ const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 fn main() {
     println!("🔢 {:<8} {}", NAME, VERSION);
 
-    let (bugout_commands_in, bugout_commands_out): (
-        Sender<ClientCommands>,
-        Receiver<ClientCommands>,
+    let (kafka_commands_in, kafka_commands_out): (
+        Sender<KafkaCommands>,
+        Receiver<KafkaCommands>,
     ) = unbounded();
 
     let (kafka_events_in, kafka_events_out): (Sender<Events>, Receiver<Events>) = unbounded();
@@ -44,7 +44,7 @@ fn main() {
     kafka::start(
         kafka_events_in,
         router_commands_in.clone(),
-        bugout_commands_out,
+        kafka_commands_out,
     );
 
     router::start(router_commands_out, kafka_events_out);
@@ -53,7 +53,7 @@ fn main() {
         WsSession::new(
             uuid::Uuid::new_v4(),
             ws_out,
-            bugout_commands_in.clone(),
+            kafka_commands_in.clone(),
             router_commands_in.clone(),
         )
     })

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -71,6 +71,14 @@ pub enum ClientCommands {
     ProvideHistory(ProvideHistoryCommand),
 }
 
+// TODO - get rid of type tag ?
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum KafkaCommands {
+    MakeMove(MakeMoveCommand),
+    ProvideHistory(ProvideHistoryCommand),
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MoveMadeEvent {
     #[serde(rename = "gameId")]

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -71,7 +71,7 @@ pub enum ClientCommands {
     ProvideHistory(ProvideHistoryCommand),
 }
 
-// TODO - get rid of type tag ?
+// https://github.com/Terkwood/BUGOUT/issues/81
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub enum KafkaCommands {

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -28,7 +28,7 @@ pub struct WsSession {
     pub ping_timeout: Option<Timeout>,
     pub expire_timeout: Option<Timeout>,
     pub channel_recv_timeout: Option<Timeout>,
-    pub bugout_commands_in: crossbeam_channel::Sender<ClientCommands>,
+    pub kafka_commands_in: crossbeam_channel::Sender<KafkaCommands>,
     pub events_out: Option<crossbeam_channel::Receiver<Events>>,
     pub router_commands_in: crossbeam_channel::Sender<RouterCommand>,
     pub current_game: Option<GameId>,
@@ -39,7 +39,7 @@ impl WsSession {
     pub fn new(
         client_id: ClientId,
         ws_out: ws::Sender,
-        bugout_commands_in: crossbeam_channel::Sender<ClientCommands>,
+        kafka_commands_in: crossbeam_channel::Sender<KafkaCommands>,
         router_commands_in: crossbeam_channel::Sender<RouterCommand>,
     ) -> WsSession {
         WsSession {
@@ -48,7 +48,7 @@ impl WsSession {
             ping_timeout: None,
             expire_timeout: None,
             channel_recv_timeout: None,
-            bugout_commands_in,
+            kafka_commands_in,
             events_out: None,
             router_commands_in,
             current_game: None,
@@ -120,8 +120,8 @@ impl Handler for WsSession {
                 if let Some(c) = self.current_game {
                     if c == game_id {
                         return self
-                            .bugout_commands_in
-                            .send(ClientCommands::MakeMove(MakeMoveCommand {
+                            .kafka_commands_in
+                            .send(KafkaCommands::MakeMove(MakeMoveCommand {
                                 game_id,
                                 req_id,
                                 player,
@@ -197,8 +197,8 @@ impl Handler for WsSession {
                 println!("📋 {} PROVHIST", session_code(self));
 
                 if let Err(e) = self
-                    .bugout_commands_in
-                    .send(ClientCommands::ProvideHistory(ProvideHistoryCommand {
+                    .kafka_commands_in
+                    .send(KafkaCommands::ProvideHistory(ProvideHistoryCommand {
                         game_id,
                         req_id,
                     }))


### PR DESCRIPTION
This change set cleans up the data model so that the `select! {  recv(kafka_out) -> command =>  match command { // ... ` in kafka.rs can be exhaustive.  Client Commands sent by the browser are now differentiated from Kafka Commands delivered to the back end.  The client commands `Beep` and `RequestOpenGame` were never used by kafka.