### PR TITLE
Gateway: support color choice

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -329,7 +329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gateway"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -22,9 +22,6 @@ RUN rustup default nightly
 # not just what's on the git branch
 COPY . /var/BUGOUT/gateway/.
 
-#TODO below
-CMD ["tail", "-f", "/dev/null"]
+RUN cargo install --path .
 
-#RUN cargo install --path .
-
-#CMD ["sh", "run.sh"]
+CMD ["sh", "run.sh"]

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -22,9 +22,6 @@ RUN rustup default nightly
 # not just what's on the git branch
 COPY . /var/BUGOUT/gateway/.
 
-#TODO BELOW
-#RUN cargo install --path .
+RUN cargo install --path .
 
-#CMD ["sh", "run.sh"]
-
-CMD ["tail","-f","/dev/null"]
+CMD ["sh", "run.sh"]

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -22,6 +22,9 @@ RUN rustup default nightly
 # not just what's on the git branch
 COPY . /var/BUGOUT/gateway/.
 
-RUN cargo install --path .
+#TODO below
+CMD ["tail", "-f", "/dev/null"]
 
-CMD ["sh", "run.sh"]
+#RUN cargo install --path .
+
+#CMD ["sh", "run.sh"]

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -22,6 +22,9 @@ RUN rustup default nightly
 # not just what's on the git branch
 COPY . /var/BUGOUT/gateway/.
 
-RUN cargo install --path .
+#TODO BELOW
+#RUN cargo install --path .
 
-CMD ["sh", "run.sh"]
+#CMD ["sh", "run.sh"]
+
+CMD ["tail","-f","/dev/null"]

--- a/gateway/src/client_commands.rs
+++ b/gateway/src/client_commands.rs
@@ -17,6 +17,12 @@ pub struct JoinPrivateGameClientCommand {
     pub game_id: CompactId,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ChooseColorPrefClientCommand {
+    #[serde(rename = "colorPref")]
+    pub color_pref: ColorPref,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "type")]
 pub enum ClientCommands {
@@ -27,6 +33,7 @@ pub enum ClientCommands {
     JoinPrivateGame(JoinPrivateGameClientCommand),
     FindPublicGame,
     CreatePrivateGame,
+    ChooseColorPref(ChooseColorPrefClientCommand),
 }
 
 #[cfg(test)]

--- a/gateway/src/client_events.rs
+++ b/gateway/src/client_events.rs
@@ -14,7 +14,8 @@ pub enum ClientEvents {
     GameReady(GameReadyClientEvent),
     PrivateGameRejected(PrivateGameRejectedClientEvent),
     WaitForOpponent(WaitForOpponentClientEvent),
-    ColorChosen(Player),
+    ColorsChosen(ColorsChosenEvent),
+    YourColor(Player),
 }
 
 impl ClientEvents {

--- a/gateway/src/client_events.rs
+++ b/gateway/src/client_events.rs
@@ -14,6 +14,7 @@ pub enum ClientEvents {
     GameReady(GameReadyClientEvent),
     PrivateGameRejected(PrivateGameRejectedClientEvent),
     WaitForOpponent(WaitForOpponentClientEvent),
+    ColorChosen(Player),
 }
 
 impl ClientEvents {

--- a/gateway/src/client_events.rs
+++ b/gateway/src/client_events.rs
@@ -14,7 +14,6 @@ pub enum ClientEvents {
     GameReady(GameReadyClientEvent),
     PrivateGameRejected(PrivateGameRejectedClientEvent),
     WaitForOpponent(WaitForOpponentClientEvent),
-    ColorsChosen(ColorsChosenEvent),
     YourColor(YourColorEvent),
 }
 

--- a/gateway/src/client_events.rs
+++ b/gateway/src/client_events.rs
@@ -15,7 +15,7 @@ pub enum ClientEvents {
     PrivateGameRejected(PrivateGameRejectedClientEvent),
     WaitForOpponent(WaitForOpponentClientEvent),
     ColorsChosen(ColorsChosenEvent),
-    YourColor(Player),
+    YourColor(YourColorEvent),
 }
 
 impl ClientEvents {
@@ -27,6 +27,7 @@ impl ClientEvents {
             ClientEvents::HistoryProvided(e) => Some(e.game_id),
             ClientEvents::GameReady(e) => Some(e.game_id),
             ClientEvents::WaitForOpponent(w) => Some(w.game_id),
+            ClientEvents::YourColor(y) => Some(y.game_id),
             _ => None, // TODO priv game rejected
         }
     }
@@ -69,4 +70,12 @@ pub struct GameReadyClientEvent {
     pub game_id: GameId,
     #[serde(rename = "eventId")]
     pub event_id: EventId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct YourColorEvent {
+    #[serde(rename = "gameId")]
+    pub game_id: GameId,
+    #[serde(rename = "yourColor")]
+    pub your_color: Player,
 }

--- a/gateway/src/kafka_commands.rs
+++ b/gateway/src/kafka_commands.rs
@@ -16,6 +16,14 @@ pub struct FindPublicGameKafkaCommand {
     pub client_id: ClientId,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ChooseColorPrefKafkaCommand {
+    #[serde(rename = "clientId")]
+    pub client_id: ClientId,
+    #[serde(rename = "colorPref")]
+    pub color_pref: ColorPref,
+}
+
 /// Gateway may manually create private games,
 /// but it will never create a public game.
 /// We omit specifying the game ID here, and
@@ -34,4 +42,5 @@ pub enum KafkaCommands {
     JoinPrivateGame(JoinPrivateGameKafkaCommand),
     FindPublicGame(FindPublicGameKafkaCommand),
     CreateGame(CreateGameKafkaCommand),
+    ChooseColorPref(ChooseColorPrefKafkaCommand),
 }

--- a/gateway/src/kafka_events.rs
+++ b/gateway/src/kafka_events.rs
@@ -11,7 +11,7 @@ pub enum KafkaEvents {
     GameReady(GameReadyKafkaEvent),
     PrivateGameRejected(PrivateGameRejectedKafkaEvent),
     WaitForOpponent(WaitForOpponentKafkaEvent),
-    ColorsChosen(ColorsChosenKafkaEvent),
+    ColorsChosen(ColorsChosen),
 }
 
 impl KafkaEvents {
@@ -95,7 +95,7 @@ pub struct PrivateGameRejectedKafkaEvent {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ColorsChosenKafkaEvent {
+pub struct ColorsChosen {
     #[serde(rename = "gameId")]
     pub game_id: GameId,
     pub black: ClientId,

--- a/gateway/src/kafka_events.rs
+++ b/gateway/src/kafka_events.rs
@@ -4,6 +4,7 @@ use crate::client_events::*;
 use crate::compact_ids::CompactId;
 use crate::model::*;
 
+#[derive(Debug)]
 pub enum KafkaEvents {
     MoveMade(MoveMadeEvent),
     MoveRejected(MoveRejectedEvent),
@@ -20,7 +21,11 @@ impl KafkaEvents {
             KafkaEvents::MoveMade(m) => ClientEvents::MoveMade(m),
             KafkaEvents::MoveRejected(m) => ClientEvents::MoveRejected(m),
             KafkaEvents::HistoryProvided(h) => ClientEvents::HistoryProvided(h),
-            KafkaEvents::ColorsChosen(c) => ClientEvents::ColorsChosen(c),
+            // Dummy impl, don't trust it
+            KafkaEvents::ColorsChosen(c) => ClientEvents::YourColor(YourColorEvent {
+                game_id: c.game_id,
+                your_color: Player::BLACK,
+            }),
             KafkaEvents::GameReady(g) => ClientEvents::GameReady(GameReadyClientEvent {
                 game_id: g.game_id,
                 event_id: g.event_id,

--- a/gateway/src/kafka_events.rs
+++ b/gateway/src/kafka_events.rs
@@ -20,6 +20,7 @@ impl KafkaEvents {
             KafkaEvents::MoveMade(m) => ClientEvents::MoveMade(m),
             KafkaEvents::MoveRejected(m) => ClientEvents::MoveRejected(m),
             KafkaEvents::HistoryProvided(h) => ClientEvents::HistoryProvided(h),
+            KafkaEvents::ColorsChosen(c) => ClientEvents::ColorsChosen(c),
             KafkaEvents::GameReady(g) => ClientEvents::GameReady(GameReadyClientEvent {
                 game_id: g.game_id,
                 event_id: g.event_id,
@@ -47,7 +48,6 @@ impl KafkaEvents {
                     link,
                 })
             }
-            KafkaEvents::ColorsChosen(_) => unimplemented!(),
         }
     }
 

--- a/gateway/src/kafka_events.rs
+++ b/gateway/src/kafka_events.rs
@@ -11,6 +11,7 @@ pub enum KafkaEvents {
     GameReady(GameReadyKafkaEvent),
     PrivateGameRejected(PrivateGameRejectedKafkaEvent),
     WaitForOpponent(WaitForOpponentKafkaEvent),
+    ColorsChosen(ColorsChosenKafkaEvent),
 }
 
 impl KafkaEvents {
@@ -46,6 +47,7 @@ impl KafkaEvents {
                     link,
                 })
             }
+            KafkaEvents::ColorsChosen(_) => unimplemented!(),
         }
     }
 
@@ -57,6 +59,7 @@ impl KafkaEvents {
             KafkaEvents::GameReady(e) => e.game_id,
             KafkaEvents::PrivateGameRejected(e) => e.game_id,
             KafkaEvents::WaitForOpponent(e) => e.game_id,
+            KafkaEvents::ColorsChosen(e) => e.game_id,
         }
     }
 }
@@ -89,4 +92,12 @@ pub struct PrivateGameRejectedKafkaEvent {
     pub client_id: ClientId,
     #[serde(rename = "eventId")]
     pub event_id: EventId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ColorsChosenKafkaEvent {
+    #[serde(rename = "gameId")]
+    pub game_id: GameId,
+    pub black: ClientId,
+    pub white: ClientId,
 }

--- a/gateway/src/kafka_events.rs
+++ b/gateway/src/kafka_events.rs
@@ -11,7 +11,7 @@ pub enum KafkaEvents {
     GameReady(GameReadyKafkaEvent),
     PrivateGameRejected(PrivateGameRejectedKafkaEvent),
     WaitForOpponent(WaitForOpponentKafkaEvent),
-    ColorsChosen(ColorsChosen),
+    ColorsChosen(ColorsChosenEvent),
 }
 
 impl KafkaEvents {
@@ -92,12 +92,4 @@ pub struct PrivateGameRejectedKafkaEvent {
     pub client_id: ClientId,
     #[serde(rename = "eventId")]
     pub event_id: EventId,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ColorsChosen {
-    #[serde(rename = "gameId")]
-    pub game_id: GameId,
-    pub black: ClientId,
-    pub white: ClientId,
 }

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -53,12 +53,16 @@ fn start_producer(kafka_out: crossbeam::Receiver<KafkaCommands>) {
                             .payload(&serde_json::to_string(&f).unwrap())
                             .key(&f.client_id.to_string()), 0); // fire & forget
                     },
-                    Ok(KafkaCommands::CreateGame(c)) =>{
+                    Ok(KafkaCommands::CreateGame(c)) => {
                         producer.send(FutureRecord::to(CREATE_GAME_TOPIC)
                             .payload(&serde_json::to_string(&c).unwrap())
                             .key(&c.client_id.to_string()), 0); // fire & forget
                     },
-                    Ok(KafkaCommands::ChooseColorPref(_)) => unimplemented!(),
+                    Ok(KafkaCommands::ChooseColorPref(_)) => {
+                        producer.send(FutureRecord::to(unimplemented!())
+                            .payload(&serde_json::to_string(&c).unwrap())
+                            .key(&c.client_id.to_string()), 0); // fire & forget
+                    },
                     Err(e) => panic!("Unable to receive command via kafka channel: {:?}", e),
                 }
         }

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -58,6 +58,7 @@ fn start_producer(kafka_out: crossbeam::Receiver<KafkaCommands>) {
                             .payload(&serde_json::to_string(&c).unwrap())
                             .key(&c.client_id.to_string()), 0); // fire & forget
                     },
+                    Ok(KafkaCommands::ChooseColorPref(_)) => unimplemented!(),
                     Err(e) => panic!("Unable to receive command via kafka channel: {:?}", e),
                 }
         }

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -162,6 +162,15 @@ fn start_consumer(
                             Ok(w) => flail_on_fail(events_in.send(KafkaEvents::WaitForOpponent(w))),
                         }
                     }
+                    COLORS_CHOSEN_TOPIC => {
+                        let deserialized: Result<ColorsChosenEvent, _> =
+                            serde_json::from_str(payload);
+
+                        match deserialized {
+                            Err(e) => println!("failed to deserialize wait for opponent {}", e),
+                            Ok(c) => flail_on_fail(events_in.send(KafkaEvents::ColorsChosen(c))),
+                        }
+                    }
                     other => println!("ERROR Couldn't match kafka events topic: {}", other),
                 }
             }

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -59,7 +59,7 @@ fn start_producer(kafka_out: crossbeam::Receiver<KafkaCommands>) {
                             .key(&c.client_id.to_string()), 0); // fire & forget
                     },
                     Ok(KafkaCommands::ChooseColorPref(c)) => {
-                        producer.send(FutureRecord::to(unimplemented!())
+                        producer.send(FutureRecord::to(CHOOSE_COLOR_PREF_TOPIC)
                             .payload(&serde_json::to_string(&c).unwrap())
                             .key(&c.client_id.to_string()), 0); // fire & forget
                     },

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -167,11 +167,8 @@ fn start_consumer(
                         }
                     }
                     COLORS_CHOSEN_TOPIC => {
-                        println!("COLOR CHOSEN KAFKA EVENT COMING THRU!");
                         let deserialized: Result<ColorsChosenEvent, _> =
                             serde_json::from_str(payload);
-
-                        println!("{:?}", deserialized);
 
                         match deserialized {
                             Err(e) => println!("failed to deserialize wait for opponent {}", e),

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -167,8 +167,11 @@ fn start_consumer(
                         }
                     }
                     COLORS_CHOSEN_TOPIC => {
+                        println!("COLOR CHOSEN KAFKA EVENT COMING THRU!");
                         let deserialized: Result<ColorsChosenEvent, _> =
                             serde_json::from_str(payload);
+
+                        println!("{:?}", deserialized);
 
                         match deserialized {
                             Err(e) => println!("failed to deserialize wait for opponent {}", e),

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -58,7 +58,7 @@ fn start_producer(kafka_out: crossbeam::Receiver<KafkaCommands>) {
                             .payload(&serde_json::to_string(&c).unwrap())
                             .key(&c.client_id.to_string()), 0); // fire & forget
                     },
-                    Ok(KafkaCommands::ChooseColorPref(_)) => {
+                    Ok(KafkaCommands::ChooseColorPref(c)) => {
                         producer.send(FutureRecord::to(unimplemented!())
                             .payload(&serde_json::to_string(&c).unwrap())
                             .key(&c.client_id.to_string()), 0); // fire & forget

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -40,6 +40,14 @@ pub enum ColorPref {
     Any,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ColorsChosenEvent {
+    #[serde(rename = "gameId")]
+    pub game_id: GameId,
+    pub black: ClientId,
+    pub white: ClientId,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct MakeMoveCommand {
     #[serde(rename = "gameId")]

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -12,7 +12,7 @@ pub struct Coord {
     pub y: u16,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]
 pub enum Player {
     BLACK,
     WHITE,

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -33,6 +33,13 @@ pub enum Visibility {
     Private,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum ColorPref {
+    Black,
+    White,
+    Any,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct MakeMoveCommand {
     #[serde(rename = "gameId")]

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -125,9 +125,8 @@ impl Router {
     }
 
     fn reconnect(&mut self, client_id: ClientId, game_id: GameId, events_in: Sender<ClientEvents>) {
-        // TODO we should store this in the clients hash as well
-        // TODO
-        // TODO
+        // TODO but does it work?
+        self.clients.insert(client_id, events_in.clone());
 
         let cs = ClientSender {
             client_id,

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -45,6 +45,8 @@ impl Router {
                     e
                 )
             }
+        } else {
+            println!("NONE :( :(") // TODO
         }
     }
 
@@ -120,6 +122,7 @@ impl Router {
                 }
             }
 
+            // Pre-emptive clean-up.  Watch out
             self.clients.remove(&client_id);
         }
     }
@@ -252,8 +255,10 @@ pub fn start(
                             router.forward_by_game_id(KafkaEvents::WaitForOpponent(w).to_client_event())
                         }
                         Ok(KafkaEvents::ColorsChosen(ColorsChosenEvent { game_id, black, white})) => {
-                            router.forward_by_client_id(black, ClientEvents::YourColor (YourColorEvent{ game_id, your_color: Player::BLACK}));
-                            router.forward_by_client_id(white, ClientEvents::YourColor(YourColorEvent{game_id, your_color: Player::WHITE}));
+                            println!("Greetings");
+                            router.forward_by_game_id( ClientEvents::YourColor (YourColorEvent{ game_id, your_color: Player::BLACK}));
+                            router.forward_by_game_id(ClientEvents::YourColor(YourColorEvent{game_id, your_color: Player::WHITE}));
+                            println!("And hi");
                             /*match event {
                             ClientEvents::ColorsChosen(ColorsChosenEvent {
                                 game_id,

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -267,7 +267,6 @@ pub fn start(
                             router.forward_by_client_id(white, ClientEvents::YourColor(YourColorEvent{game_id, your_color: Player::WHITE}));
                         },
                         Ok(e) => {
-                            println!("EVENT OBSERVED IN ROUTER {:?}", e);
                             router.observed(e.game_id());
                             router.forward_by_game_id(e.to_client_event())
                         },

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -8,7 +8,7 @@ use crossbeam_channel::select;
 
 use uuid::Uuid;
 
-use crate::client_events::ClientEvents;
+use crate::client_events::{ClientEvents, YourColorEvent};
 use crate::kafka_events::KafkaEvents;
 use crate::logging::{short_uuid, EMPTY_SHORT_UUID};
 use crate::model::*;
@@ -251,7 +251,55 @@ pub fn start(
                             router.route_new_game(w.client_id, w.game_id);
                             router.forward_by_game_id(KafkaEvents::WaitForOpponent(w).to_client_event())
                         }
+                        Ok(KafkaEvents::ColorsChosen(ColorsChosenEvent { game_id, black, white})) => {
+                            router.forward_by_client_id(black, ClientEvents::YourColor (YourColorEvent{ game_id, your_color: Player::BLACK}));
+                            router.forward_by_client_id(white, ClientEvents::YourColor(YourColorEvent{game_id, your_color: Player::WHITE}));
+                            /*match event {
+                            ClientEvents::ColorsChosen(ColorsChosenEvent {
+                                game_id,
+                                black,
+                                white,
+                            }) => match self.client_id {
+                                b if b == black => {
+                                    println!(
+                                        "🏴 {} {:<8} {:?}",
+                                        session_code(self),
+                                        "YOURCOLR",
+                                        Player::BLACK
+                                    );
+                                    self.ws_out.send(
+                                        serde_json::to_string(&ClientEvents::YourColor(
+                                            YourColorEvent {
+                                                game_id,
+                                                your_color: Player::BLACK,
+                                            },
+                                        ))
+                                        .unwrap(),
+                                    )?
+                                }
+                                w if w == white => {
+                                    println!(
+                                        "🏳 {} {:<8} {:?}",
+                                        session_code(self),
+                                        "YOURCOLR",
+                                        Player::WHITE
+                                    );
+                                    self.ws_out.send(
+                                        serde_json::to_string(&ClientEvents::YourColor(
+                                            YourColorEvent {
+                                                game_id,
+                                                your_color: Player::WHITE,
+                                            },
+                                        ))
+                                        .unwrap(),
+                                    )?
+                                }
+                                _ => println!("😤 COULD NOT MATCH CLIENT TO COLOR"),
+                            },*/
+
+                        },
                         Ok(e) => {
+                            println!("EVENT OBSERVED IN ROUTER {:?}", e);
                             router.observed(e.game_id());
                             router.forward_by_game_id(e.to_client_event())
                         },

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -265,50 +265,6 @@ pub fn start(
                             // to each client
                             router.forward_by_client_id( black,ClientEvents::YourColor (YourColorEvent{ game_id, your_color: Player::BLACK}));
                             router.forward_by_client_id(white, ClientEvents::YourColor(YourColorEvent{game_id, your_color: Player::WHITE}));
-                            println!("And hi");
-                            /*match event {
-                            ClientEvents::ColorsChosen(ColorsChosenEvent {
-                                game_id,
-                                black,
-                                white,
-                            }) => match self.client_id {
-                                b if b == black => {
-                                    println!(
-                                        "🏴 {} {:<8} {:?}",
-                                        session_code(self),
-                                        "YOURCOLR",
-                                        Player::BLACK
-                                    );
-                                    self.ws_out.send(
-                                        serde_json::to_string(&ClientEvents::YourColor(
-                                            YourColorEvent {
-                                                game_id,
-                                                your_color: Player::BLACK,
-                                            },
-                                        ))
-                                        .unwrap(),
-                                    )?
-                                }
-                                w if w == white => {
-                                    println!(
-                                        "🏳 {} {:<8} {:?}",
-                                        session_code(self),
-                                        "YOURCOLR",
-                                        Player::WHITE
-                                    );
-                                    self.ws_out.send(
-                                        serde_json::to_string(&ClientEvents::YourColor(
-                                            YourColorEvent {
-                                                game_id,
-                                                your_color: Player::WHITE,
-                                            },
-                                        ))
-                                        .unwrap(),
-                                    )?
-                                }
-                                _ => println!("😤 COULD NOT MATCH CLIENT TO COLOR"),
-                            },*/
-
                         },
                         Ok(e) => {
                             println!("EVENT OBSERVED IN ROUTER {:?}", e);

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -125,9 +125,9 @@ impl Router {
     }
 
     fn reconnect(&mut self, client_id: ClientId, game_id: GameId, events_in: Sender<ClientEvents>) {
-        // TODO we should store this in the clients hash as well 
-// TODO
-// TODO
+        // TODO we should store this in the clients hash as well
+        // TODO
+        // TODO
 
         let cs = ClientSender {
             client_id,

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -263,7 +263,7 @@ pub fn start(
                             // We want to forward by client ID
                             // so that we don't send TWO yourcolor events
                             // to each client
-                            router.forward_by_client_id( black,ClientEvents::YourColor (YourColorEvent{ game_id, your_color: Player::BLACK}));
+                            router.forward_by_client_id(black,ClientEvents::YourColor (YourColorEvent{ game_id, your_color: Player::BLACK}));
                             router.forward_by_client_id(white, ClientEvents::YourColor(YourColorEvent{game_id, your_color: Player::WHITE}));
                         },
                         Ok(e) => {

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -125,7 +125,6 @@ impl Router {
     }
 
     fn reconnect(&mut self, client_id: ClientId, game_id: GameId, events_in: Sender<ClientEvents>) {
-        // TODO but does it work?
         self.clients.insert(client_id, events_in.clone());
 
         let cs = ClientSender {

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -46,7 +46,7 @@ impl Router {
                 )
             }
         } else {
-            println!("NONE :( :(") // TODO
+            println!("Could not forward to client ID, perhaps it was already cleaned up by route_new_game ?")
         }
     }
 

--- a/gateway/src/topics.rs
+++ b/gateway/src/topics.rs
@@ -3,6 +3,7 @@ pub const PROVIDE_HISTORY_TOPIC: &str = "bugout-provide-history-cmd";
 pub const JOIN_PRIVATE_GAME_TOPIC: &str = "bugout-join-private-game-cmd";
 pub const FIND_PUBLIC_GAME_TOPIC: &str = "bugout-find-public-game-cmd";
 pub const CREATE_GAME_TOPIC: &str = "bugout-create-game-cmd";
+pub const CHOOSE_COLOR_PREF_TOPIC: &str = "bugout-choose-color-pref-cmd";
 
 pub const MOVE_MADE_TOPIC: &str = "bugout-move-made-ev";
 pub const HISTORY_PROVIDED_TOPIC: &str = "bugout-history-provided-ev";

--- a/gateway/src/topics.rs
+++ b/gateway/src/topics.rs
@@ -9,6 +9,7 @@ pub const HISTORY_PROVIDED_TOPIC: &str = "bugout-history-provided-ev";
 pub const PRIVATE_GAME_REJECTED_TOPIC: &str = "bugout-private-game-rejected-ev";
 pub const GAME_READY_TOPIC: &str = "bugout-game-ready-ev";
 pub const WAIT_FOR_OPPONENT_TOPIC: &str = "bugout-wait-for-opponent-ev";
+pub const COLORS_CHOSEN_TOPIC: &str = "bugout-colors-chosen-ev";
 
 pub const CONSUME_TOPICS: &[&str] = &[
     MOVE_MADE_TOPIC,
@@ -16,4 +17,5 @@ pub const CONSUME_TOPICS: &[&str] = &[
     PRIVATE_GAME_REJECTED_TOPIC,
     GAME_READY_TOPIC,
     WAIT_FOR_OPPONENT_TOPIC,
+    COLORS_CHOSEN_TOPIC,
 ];

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -399,7 +399,12 @@ impl Handler for WsSession {
                             _ => (),
                         }
 
-                        self.ws_out.send(serde_json::to_string(&event).unwrap())?;
+                        match event {
+                            // TODO transform this to a YourColor event
+                            // TODO based on the client ID linked to session
+                            ClientEvents::ColorsChosen(_) => unimplemented!(),
+                            _ => self.ws_out.send(serde_json::to_string(&event).unwrap())?,
+                        }
                     }
                 }
                 self.channel_recv_timeout.take();

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -309,11 +309,16 @@ impl Handler for WsSession {
                 }
                 Ok(self.observe())
             }
-            Ok(ClientCommands::ChooseColorPref(_)) => {
+            Ok(ClientCommands::ChooseColorPref(ChooseColorPrefClientCommand { color_pref })) => {
                 println!("🗳 {} CHSCLRPF", session_code(self));
 
                 self.kafka_commands_in
-                    .send(KafkaCommands::ChooseColorPref(unimplemented!()))
+                    .send(KafkaCommands::ChooseColorPref(
+                        ChooseColorPrefKafkaCommand {
+                            client_id: self.client_id,
+                            color_pref,
+                        },
+                    ))
                     .map_err(|e| ws::Error::from(Box::new(e)))
             }
             Err(_err) => {

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -309,7 +309,13 @@ impl Handler for WsSession {
                 }
                 Ok(self.observe())
             }
-            Ok(ClientCommands::ChooseColorPref(_)) => unimplemented!(),
+            Ok(ClientCommands::ChooseColorPref(_)) => {
+                println!("🗳 {} CHSCLRPF", session_code(self));
+
+                self.kafka_commands_in
+                    .send(KafkaCommands::ChooseColorPref(unimplemented!()))
+                    .map_err(|e| ws::Error::from(Box::new(e)))
+            }
             Err(_err) => {
                 println!(
                     "💥 {} {:<8} message deserialization {}",

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -307,9 +307,9 @@ impl Handler for WsSession {
                 } else {
                     println!("🏴‍☠️ FAILED TO DECODE PRIVATE GAME ID 🏴‍☠️")
                 }
-
                 Ok(self.observe())
             }
+            Ok(ClientCommands::ChooseColorPref(_)) => unimplemented!(),
             Err(_err) => {
                 println!(
                     "💥 {} {:<8} message deserialization {}",

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -407,6 +407,22 @@ impl Handler for WsSession {
                                 self.current_game = Some(game_id);
                                 println!("⏳ {} {:<8}", session_code(self), "WAITOPPO");
                             }
+                            ClientEvents::YourColor(YourColorEvent {
+                                game_id: _,
+                                your_color,
+                            })
+                                if your_color == Player::BLACK =>
+                            {
+                                println!("🏴 {} {:<8} Black", session_code(self), "YOURCOLR")
+                            }
+                            ClientEvents::YourColor(YourColorEvent {
+                                game_id: _,
+                                your_color,
+                            })
+                                if your_color == Player::WHITE =>
+                            {
+                                println!("🏳 {} {:<8} White", session_code(self), "YOURCOLR")
+                            }
                             _ => (),
                         }
 

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -411,50 +411,8 @@ impl Handler for WsSession {
                         }
 
                         println!("OH HEY IT'S AN EVENT {:?}", event);
-                        match event {
-                            ClientEvents::ColorsChosen(ColorsChosenEvent {
-                                game_id,
-                                black,
-                                white,
-                            }) => match self.client_id {
-                                b if b == black => {
-                                    println!(
-                                        "🏴 {} {:<8} {:?}",
-                                        session_code(self),
-                                        "YOURCOLR",
-                                        Player::BLACK
-                                    );
-                                    self.ws_out.send(
-                                        serde_json::to_string(&ClientEvents::YourColor(
-                                            YourColorEvent {
-                                                game_id,
-                                                your_color: Player::BLACK,
-                                            },
-                                        ))
-                                        .unwrap(),
-                                    )?
-                                }
-                                w if w == white => {
-                                    println!(
-                                        "🏳 {} {:<8} {:?}",
-                                        session_code(self),
-                                        "YOURCOLR",
-                                        Player::WHITE
-                                    );
-                                    self.ws_out.send(
-                                        serde_json::to_string(&ClientEvents::YourColor(
-                                            YourColorEvent {
-                                                game_id,
-                                                your_color: Player::WHITE,
-                                            },
-                                        ))
-                                        .unwrap(),
-                                    )?
-                                }
-                                _ => println!("😤 COULD NOT MATCH CLIENT TO COLOR"),
-                            },
-                            _ => self.ws_out.send(serde_json::to_string(&event).unwrap())?,
-                        }
+
+                        self.ws_out.send(serde_json::to_string(&event).unwrap())?
                     }
                 }
                 self.channel_recv_timeout.take();

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -434,7 +434,7 @@ impl Handler for WsSession {
                                     ))
                                     .unwrap(),
                                 )?,
-                                _ => panic!(" COULD NOT MATCH COLOR TO CLIENT "),
+                                _ => println!("😤 COULD NOT MATCH CLIENT TO COLOR"),
                             },
                             _ => self.ws_out.send(serde_json::to_string(&event).unwrap())?,
                         }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -416,7 +416,9 @@ impl Handler for WsSession {
                                 black,
                                 white,
                             }) => match self.client_id {
-                                b if b == black => self.ws_out.send(
+                                b if b == black => { 
+                                    println!("⏳ {} {:<8} {:?}", session_code(self), "YOURCOLR", Player::BLACK);
+                                    self.ws_out.send(
                                     serde_json::to_string(&ClientEvents::YourColor(
                                         YourColorEvent {
                                             game_id,
@@ -424,8 +426,11 @@ impl Handler for WsSession {
                                         },
                                     ))
                                     .unwrap(),
-                                )?,
-                                w if w == white => self.ws_out.send(
+                                )? },
+                                w if w == white => {
+
+                                    println!("⏳ {} {:<8} {:?}", session_code(self), "YOURCOLR", Player::WHITE);
+                                    self.ws_out.send(
                                     serde_json::to_string(&ClientEvents::YourColor(
                                         YourColorEvent {
                                             game_id,
@@ -433,7 +438,8 @@ impl Handler for WsSession {
                                         },
                                     ))
                                     .unwrap(),
-                                )?,
+                                )?
+                                },
                                 _ => println!("😤 COULD NOT MATCH CLIENT TO COLOR"),
                             },
                             _ => self.ws_out.send(serde_json::to_string(&event).unwrap())?,

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -400,9 +400,31 @@ impl Handler for WsSession {
                         }
 
                         match event {
-                            // TODO transform this to a YourColor event
-                            // TODO based on the client ID linked to session
-                            ClientEvents::ColorsChosen(_) => unimplemented!(),
+                            ClientEvents::ColorsChosen(ColorsChosenEvent {
+                                game_id,
+                                black,
+                                white,
+                            }) => match self.client_id {
+                                b if b == black => self.ws_out.send(
+                                    serde_json::to_string(&ClientEvents::YourColor(
+                                        YourColorEvent {
+                                            game_id,
+                                            your_color: Player::BLACK,
+                                        },
+                                    ))
+                                    .unwrap(),
+                                )?,
+                                w if w == white => self.ws_out.send(
+                                    serde_json::to_string(&ClientEvents::YourColor(
+                                        YourColorEvent {
+                                            game_id,
+                                            your_color: Player::WHITE,
+                                        },
+                                    ))
+                                    .unwrap(),
+                                )?,
+                                _ => panic!(" COULD NOT MATCH COLOR TO CLIENT "),
+                            },
                             _ => self.ws_out.send(serde_json::to_string(&event).unwrap())?,
                         }
                     }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -410,36 +410,47 @@ impl Handler for WsSession {
                             _ => (),
                         }
 
+                        println!("OH HEY IT'S AN EVENT {:?}", event);
                         match event {
                             ClientEvents::ColorsChosen(ColorsChosenEvent {
                                 game_id,
                                 black,
                                 white,
                             }) => match self.client_id {
-                                b if b == black => { 
-                                    println!("⏳ {} {:<8} {:?}", session_code(self), "YOURCOLR", Player::BLACK);
+                                b if b == black => {
+                                    println!(
+                                        "🏴 {} {:<8} {:?}",
+                                        session_code(self),
+                                        "YOURCOLR",
+                                        Player::BLACK
+                                    );
                                     self.ws_out.send(
-                                    serde_json::to_string(&ClientEvents::YourColor(
-                                        YourColorEvent {
-                                            game_id,
-                                            your_color: Player::BLACK,
-                                        },
-                                    ))
-                                    .unwrap(),
-                                )? },
+                                        serde_json::to_string(&ClientEvents::YourColor(
+                                            YourColorEvent {
+                                                game_id,
+                                                your_color: Player::BLACK,
+                                            },
+                                        ))
+                                        .unwrap(),
+                                    )?
+                                }
                                 w if w == white => {
-
-                                    println!("⏳ {} {:<8} {:?}", session_code(self), "YOURCOLR", Player::WHITE);
+                                    println!(
+                                        "🏳 {} {:<8} {:?}",
+                                        session_code(self),
+                                        "YOURCOLR",
+                                        Player::WHITE
+                                    );
                                     self.ws_out.send(
-                                    serde_json::to_string(&ClientEvents::YourColor(
-                                        YourColorEvent {
-                                            game_id,
-                                            your_color: Player::WHITE,
-                                        },
-                                    ))
-                                    .unwrap(),
-                                )?
-                                },
+                                        serde_json::to_string(&ClientEvents::YourColor(
+                                            YourColorEvent {
+                                                game_id,
+                                                your_color: Player::WHITE,
+                                            },
+                                        ))
+                                        .unwrap(),
+                                    )?
+                                }
                                 _ => println!("😤 COULD NOT MATCH CLIENT TO COLOR"),
                             },
                             _ => self.ws_out.send(serde_json::to_string(&event).unwrap())?,

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -410,8 +410,6 @@ impl Handler for WsSession {
                             _ => (),
                         }
 
-                        println!("OH HEY IT'S AN EVENT {:?}", event);
-
                         self.ws_out.send(serde_json::to_string(&event).unwrap())?
                     }
                 }


### PR DESCRIPTION
# Gateway: support color choice

Allow the gateway to support color preference voting, and to return a `YourColor` event when the system has decided who will play what.

Resolves #84.

The reconnection logic and client cleanup has been slightly altered to accommodate this flow.

## Line items

- [x] write stuff
- [x] address review comments
- [x] finish Sabaki changes
- [x] format
- [x] test reconnect logic

## Also see

[The Sabaki PR related to](https://github.com/Terkwood/Sabaki/pull/26) these changes
