### PR TITLE
Wait for kafka topics

### DIFF
--- a/changelog/build.gradle
+++ b/changelog/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'terkwood.farm'
-version '0.0.2'
+version '0.1.0'
 
 apply plugin: 'kotlin'
 apply plugin: 'application'

--- a/changelog/run.sh
+++ b/changelog/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./wait-for-it.sh kafka:9092 -s -- sleep 16 
+./wait-for-it.sh kafka:9092 -s
 java -jar bugout.changelog.jar

--- a/changelog/src/main/kotlin/Topics.kt
+++ b/changelog/src/main/kotlin/Topics.kt
@@ -1,4 +1,8 @@
-const val MOVE_ACCEPTED_EV_TOPIC = "bugout-move-accepted-ev"
-const val MOVE_MADE_EV_TOPIC = "bugout-move-made-ev"
-const val GAME_STATES_STORE_NAME = "bugout-game-states-store"
-const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"
+object Topics {
+    const val MOVE_ACCEPTED_EV_TOPIC = "bugout-move-accepted-ev"
+    const val MOVE_MADE_EV_TOPIC = "bugout-move-made-ev"
+    const val GAME_STATES_STORE_NAME = "bugout-game-states-store"
+    const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"
+
+    val all = arrayOf(MOVE_ACCEPTED_EV_TOPIC, MOVE_MADE_EV_TOPIC, GAME_STATES_CHANGELOG_TOPIC)
+}

--- a/color-chooser/build.gradle
+++ b/color-chooser/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'farm.terkwood'
-version '0.0.1'
+version '0.1.0'
 
 apply plugin: 'kotlin'
 apply plugin: 'application'

--- a/color-chooser/run.sh
+++ b/color-chooser/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./wait-for-it.sh kafka:9092 -s -- sleep 16
+./wait-for-it.sh kafka:9092 -s
 java -jar bugout.color-chooser.jar

--- a/color-chooser/src/main/kotlin/Topics.kt
+++ b/color-chooser/src/main/kotlin/Topics.kt
@@ -5,4 +5,7 @@ object Topics {
     const val GAME_COLOR_PREF = "bugout-game-color-pref-ev"
     const val COLOR_PREFS_STORE = "bugout-color-prefs-store"
     const val COLORS_CHOSEN = "bugout-colors-chosen-ev"
+
+    val all = arrayOf(CHOOSE_COLOR_PREF, GAME_READY, CLIENT_GAME_READY,
+        GAME_COLOR_PREF, COLORS_CHOSEN)
 }

--- a/game-lobby/Dockerfile
+++ b/game-lobby/Dockerfile
@@ -9,6 +9,3 @@ COPY . .
 RUN sh build.sh
 
 CMD ["sh", "run.sh"]
-
-#TODO
-#CMD ["tail", "-f", "/dev/null"]

--- a/game-lobby/Dockerfile
+++ b/game-lobby/Dockerfile
@@ -6,8 +6,9 @@ RUN chmod 755 wait-for-it.sh
 
 COPY . .
 
-#RUN sh build.sh
+RUN sh build.sh
 
-#CMD ["sh", "run.sh"]
+CMD ["sh", "run.sh"]
 
-CMD ["tail", "-f", "/dev/null"]
+#TODO
+#CMD ["tail", "-f", "/dev/null"]

--- a/game-lobby/Dockerfile
+++ b/game-lobby/Dockerfile
@@ -6,6 +6,8 @@ RUN chmod 755 wait-for-it.sh
 
 COPY . .
 
-RUN sh build.sh
+#RUN sh build.sh
 
-CMD ["sh", "run.sh"]
+#CMD ["sh", "run.sh"]
+
+CMD ["tail", "-f", "/dev/null"]

--- a/game-lobby/build.gradle
+++ b/game-lobby/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'farm.terkwood'
-version '0.1.0'
+version '0.1.1'
 
 apply plugin: 'kotlin'
 apply plugin: 'application'

--- a/game-lobby/run.sh
+++ b/game-lobby/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./wait-for-it.sh kafka:9092 -s -- sleep 16
+./wait-for-it.sh kafka:9092 -s
 java -jar bugout.game-lobby.jar

--- a/game-lobby/src/main/kotlin/Application.kt
+++ b/game-lobby/src/main/kotlin/Application.kt
@@ -33,6 +33,8 @@ class Application(private val brokers: String) {
 
         val streams = KafkaStreams(topology, props)
 
+        waitForTopics(Topics.all, props)
+
         streams.start()
 
         waitUntilStoreIsQueryable(Topics.GAME_LOBBY_STORE_LOCAL, streams)
@@ -527,10 +529,20 @@ class Application(private val brokers: String) {
         }
     }
 
-    private fun waitForTopics(topics: Array<String>, props: java.util.Properties) {
+    private fun waitForTopics(topics: Array<String>, props: java.util
+    .Properties) : Boolean{
+        print("Topics ready?")
+
         val client = AdminClient.create(props)
         val found = client.listTopics().names().get()
         println("found topics $found")
+
+        val ok = found?.filterNotNull()?.subtract(topics.toSet())?.isEmpty()
+            ?: false
+
+        println("...$ok")
+
+        return ok
     }
 }
 

--- a/game-lobby/src/main/kotlin/Application.kt
+++ b/game-lobby/src/main/kotlin/Application.kt
@@ -531,18 +531,19 @@ class Application(private val brokers: String) {
 
     private fun waitForTopics(topics: Array<String>, props: java.util
     .Properties) : Boolean{
-        print("Topics ready?")
-
         val client = AdminClient.create(props)
         val found = client.listTopics().names().get()
         println("found topics $found")
 
-        val ok = found?.filterNotNull()?.subtract(topics.toSet())?.isEmpty()
-            ?: false
+        val diff = found?.filterNotNull()?.subtract(topics.toSet())
+
+        println("diff $diff")
+
+        val ok = diff?.isEmpty()
 
         println("...$ok")
 
-        return ok
+        return ok ?: false
     }
 }
 

--- a/game-lobby/src/main/kotlin/Application.kt
+++ b/game-lobby/src/main/kotlin/Application.kt
@@ -37,7 +37,7 @@ class Application(private val brokers: String) {
 
         streams.start()
     }
-    
+
     fun build(): Topology {
         val streamsBuilder = StreamsBuilder()
 
@@ -162,7 +162,7 @@ class Application(private val brokers: String) {
                                 g.gameId == jpg.gameId
                     }
 
-                println("Popping public game  ${someGame.gameId.short()}")
+                println("Popping private game  ${someGame.gameId.short()}")
 
                 KeyValue(
                     jpg.clientId,

--- a/game-lobby/src/main/kotlin/Application.kt
+++ b/game-lobby/src/main/kotlin/Application.kt
@@ -530,20 +530,27 @@ class Application(private val brokers: String) {
     }
 
     private fun waitForTopics(topics: Array<String>, props: java.util
-    .Properties) : Boolean{
+    .Properties) {
+        print("Waiting for topics ")
         val client = AdminClient.create(props)
-        val found = client.listTopics().names().get()
-        println("found topics $found")
 
-        val diff = found?.filterNotNull()?.subtract(topics.toSet())
+        var topicsReady = false
+        while(!topicsReady) {
 
-        println("diff $diff")
+            val found = client.listTopics().names().get()
+            //println("found topics $found")
 
-        val ok = diff?.isEmpty()
+            val diff = topics.subtract(found.filterNotNull())
 
-        println("...$ok")
+            //println("diff $diff")
 
-        return ok ?: false
+            topicsReady = diff.isEmpty()
+
+            if (!topicsReady) Thread.sleep(333)
+            println(".")
+        }
+
+        println(" done!")
     }
 }
 

--- a/game-lobby/src/main/kotlin/Application.kt
+++ b/game-lobby/src/main/kotlin/Application.kt
@@ -1,3 +1,5 @@
+import org.apache.kafka.clients.KafkaClient
+import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.common.utils.Bytes
 import org.apache.kafka.streams.*
@@ -11,9 +13,11 @@ import org.apache.kafka.streams.errors.InvalidStateStoreException
 import org.apache.kafka.streams.state.QueryableStoreTypes
 
 
+const val BROKERS = "kafka:9092"
+
 fun main() {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
-    Application("kafka:9092").process()
+    Application(BROKERS).process()
 }
 
 class Application(private val brokers: String) {
@@ -29,10 +33,10 @@ class Application(private val brokers: String) {
 
         val streams = KafkaStreams(topology, props)
 
+        streams.start()
+
         waitUntilStoreIsQueryable(Topics.GAME_LOBBY_STORE_LOCAL, streams)
         waitUntilStoreIsQueryable(Topics.GAME_LOBBY_STORE_GLOBAL, streams)
-
-        streams.start()
     }
 
 
@@ -521,6 +525,12 @@ class Application(private val brokers: String) {
                 timeSpentWaitingMs += waitMs
             }
         }
+    }
+
+    private fun waitForTopics(topics: Array<String>, props: java.util.Properties) {
+        val client = AdminClient.create(props)
+        val found = client.listTopics().names().get()
+        println("found topics $found")
     }
 }
 

--- a/game-lobby/src/main/kotlin/Application.kt
+++ b/game-lobby/src/main/kotlin/Application.kt
@@ -536,18 +536,14 @@ class Application(private val brokers: String) {
 
         var topicsReady = false
         while(!topicsReady) {
-
             val found = client.listTopics().names().get()
-            //println("found topics $found")
 
             val diff = topics.subtract(found.filterNotNull())
-
-            //println("diff $diff")
 
             topicsReady = diff.isEmpty()
 
             if (!topicsReady) Thread.sleep(333)
-            println(".")
+            print(".")
         }
 
         println(" done!")

--- a/game-lobby/src/main/kotlin/Application.kt
+++ b/game-lobby/src/main/kotlin/Application.kt
@@ -505,16 +505,20 @@ class Application(private val brokers: String) {
 
     private fun waitUntilStoreIsQueryable(storeName: String, streams:
     KafkaStreams) {
-        println("Waiting for $storeName")
+        print("Waiting for $storeName ...")
+
+        var timeSpentWaitingMs = 0L
+        val waitMs = 100L
 
         while (true) {
             try {
                 streams.store(storeName, QueryableStoreTypes
                     .keyValueStore<Bytes, ByteArray>())
-                return
+                return println("$timeSpentWaitingMs ms")
             } catch (ignored: InvalidStateStoreException) {
                 // store not yet ready for querying
-                Thread.sleep(100)
+                Thread.sleep(waitMs)
+                timeSpentWaitingMs += waitMs
             }
         }
     }

--- a/game-lobby/src/main/kotlin/Application.kt
+++ b/game-lobby/src/main/kotlin/Application.kt
@@ -36,12 +36,8 @@ class Application(private val brokers: String) {
         waitForTopics(Topics.all, props)
 
         streams.start()
-
-        waitUntilStoreIsQueryable(Topics.GAME_LOBBY_STORE_LOCAL, streams)
-        waitUntilStoreIsQueryable(Topics.GAME_LOBBY_STORE_GLOBAL, streams)
     }
-
-
+    
     fun build(): Topology {
         val streamsBuilder = StreamsBuilder()
 
@@ -507,26 +503,6 @@ class Application(private val brokers: String) {
                 Produced.with(Serdes.UUID(), Serdes.String())
             )
 
-    }
-
-    private fun waitUntilStoreIsQueryable(storeName: String, streams:
-    KafkaStreams) {
-        print("Waiting for $storeName ...")
-
-        var timeSpentWaitingMs = 0L
-        val waitMs = 100L
-
-        while (true) {
-            try {
-                streams.store(storeName, QueryableStoreTypes
-                    .keyValueStore<Bytes, ByteArray>())
-                return println("$timeSpentWaitingMs ms")
-            } catch (ignored: InvalidStateStoreException) {
-                // store not yet ready for querying
-                Thread.sleep(waitMs)
-                timeSpentWaitingMs += waitMs
-            }
-        }
     }
 
     private fun waitForTopics(topics: Array<String>, props: java.util

--- a/game-lobby/src/main/kotlin/Topics.kt
+++ b/game-lobby/src/main/kotlin/Topics.kt
@@ -8,8 +8,15 @@ object Topics {
 
     const val GAME_LOBBY_COMMANDS = "bugout-game-lobby-commands"
     const val GAME_LOBBY_CHANGELOG = "bugout-game-lobby"
+
+    const val GAME_STATES_CHANGELOG = "bugout-game-states"
+
+    // kv stores
     const val GAME_LOBBY_STORE_LOCAL = "bugout-game-lobby-store-local"
     const val GAME_LOBBY_STORE_GLOBAL = "bugout-game-lobby-store-global"
 
-    const val GAME_STATES_CHANGELOG = "bugout-game-states"
+
+    val all = arrayOf(FIND_PUBLIC_GAME, CREATE_GAME, WAIT_FOR_OPPONENT,
+        GAME_READY, PRIVATE_GAME_REJECTED, JOIN_PRIVATE_GAME,
+        GAME_LOBBY_COMMANDS, GAME_LOBBY_CHANGELOG, GAME_STATES_CHANGELOG)
 }

--- a/history-provider/build.gradle
+++ b/history-provider/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'farm.terkwood'
-version '0.0.2'
+version '0.1.0'
 
 apply plugin: 'kotlin'
 apply plugin: 'application'

--- a/history-provider/run.sh
+++ b/history-provider/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./wait-for-it.sh kafka:9092 -s -- sleep 16 
+./wait-for-it.sh kafka:9092 -s
 java -jar bugout.historyprovider.jar

--- a/history-provider/src/main/kotlin/HistoryProvider.kt
+++ b/history-provider/src/main/kotlin/HistoryProvider.kt
@@ -1,3 +1,8 @@
+import Topics.GAME_STATES_CHANGELOG_TOPIC
+import Topics.GAME_STATES_STORE_NAME
+import Topics.HISTORY_PROVIDED_TOPIC
+import Topics.PROVIDE_HISTORY_TOPIC
+import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.common.utils.Bytes
 import org.apache.kafka.streams.KafkaStreams
@@ -105,5 +110,26 @@ class HistoryProvider(private val brokers: String) {
 
         val streams = KafkaStreams(topology, props)
         streams.start()
+    }
+
+
+    private fun waitForTopics(topics: Array<String>, props: java.util
+    .Properties) {
+        print("Waiting for topics ")
+        val client = AdminClient.create(props)
+
+        var topicsReady = false
+        while(!topicsReady) {
+            val found = client.listTopics().names().get()
+
+            val diff = topics.subtract(found.filterNotNull())
+
+            topicsReady = diff.isEmpty()
+
+            if (!topicsReady) Thread.sleep(333)
+            print(".")
+        }
+
+        println(" done!")
     }
 }

--- a/history-provider/src/main/kotlin/Topics.kt
+++ b/history-provider/src/main/kotlin/Topics.kt
@@ -1,4 +1,9 @@
-const val GAME_STATES_STORE_NAME = "bugout-game-states-store-history-provider"
-const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"
-const val PROVIDE_HISTORY_TOPIC = "bugout-provide-history-cmd"
-const val HISTORY_PROVIDED_TOPIC = "bugout-history-provided-ev"
+object Topics {
+    const val GAME_STATES_STORE_NAME =
+        "bugout-game-states-store-history-provider"
+    const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"
+    const val PROVIDE_HISTORY_TOPIC = "bugout-provide-history-cmd"
+    const val HISTORY_PROVIDED_TOPIC = "bugout-history-provided-ev"
+
+    val all = arrayOf(GAME_STATES_CHANGELOG_TOPIC, PROVIDE_HISTORY_TOPIC, HISTORY_PROVIDED_TOPIC)
+}

--- a/judge/build.gradle
+++ b/judge/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'terkwood.farm'
-version '0.0.3'
+version '0.1.0'
 
 apply plugin: 'kotlin'
 apply plugin: 'application'

--- a/judge/run.sh
+++ b/judge/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./wait-for-it.sh kafka:9092 -s -- sleep 16
+./wait-for-it.sh kafka:9092 -s
 java -jar bugout.judge.jar

--- a/judge/src/main/kotlin/Constants.kt
+++ b/judge/src/main/kotlin/Constants.kt
@@ -1,7 +1,11 @@
 const val FULL_BOARD_SIZE = 19
 
-const val MAKE_MOVE_CMD_TOPIC = "bugout-make-move-cmd"
-const val MOVE_ACCEPTED_EV_TOPIC = "bugout-move-accepted-ev"
-const val MOVE_REJECTED_EV_TOPIC = "bugout-move-rejected-ev"
-const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"
-const val GAME_STATES_STORE = "bugout-game-states-store-judge"
+object Topics {
+    const val MAKE_MOVE_CMD_TOPIC = "bugout-make-move-cmd"
+    const val MOVE_ACCEPTED_EV_TOPIC = "bugout-move-accepted-ev"
+    const val MOVE_REJECTED_EV_TOPIC = "bugout-move-rejected-ev"
+    const val GAME_STATES_CHANGELOG_TOPIC = "bugout-game-states"
+    const val GAME_STATES_STORE = "bugout-game-states-store-judge"
+
+    val all = arrayOf(MAKE_MOVE_CMD_TOPIC, MOVE_ACCEPTED_EV_TOPIC, MOVE_REJECTED_EV_TOPIC)
+}


### PR DESCRIPTION
Force all kafka streams services to check for their kafka topics before initializing their streams.

Resolves #112.  Resolves #96.
