### PR TITLE
Gateway: trim unused field

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -216,7 +216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gateway"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -19,7 +19,6 @@ const GAME_CLIENT_CLEANUP_PERIOD_MS: u64 = 10_000;
 /// Keeps track of clients interested in various games
 /// Each client has an associated crossbeam Sender for BUGOUT events
 struct Router {
-    pub available_games: Vec<GameId>,
     pub game_clients: HashMap<GameId, GameClients>,
     pub last_cleanup: Instant,
     pub clients: HashMap<ClientId, Sender<ClientEvents>>,
@@ -28,7 +27,6 @@ struct Router {
 impl Router {
     pub fn new() -> Router {
         Router {
-            available_games: vec![],
             game_clients: HashMap::new(),
             last_cleanup: Instant::now(),
             clients: HashMap::new(),


### PR DESCRIPTION
Removes a worthless field from `Router` struct