### PR TITLE
Gateway: process QUIT command

### DIFF
--- a/build-gateway.sh
+++ b/build-gateway.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sh clean-build.sh gateway
+sh cargo-clean-build.sh gateway

--- a/dc-giant.yml
+++ b/dc-giant.yml
@@ -16,7 +16,7 @@ services:
     environment:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${HOSTNAME}:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1,bugout-provide-history-cmd:1:1,bugout-history-provided-ev:1:1,bugout-find-public-game-cmd:1:1,bugout-create-game-cmd:1:1,bugout-wait-for-opponent-ev:1:1,bugout-game-ready-ev:1:1,bugout-private-game-rejected-ev:1:1,bugout-join-private-game-cmd:1:1,bugout-game-lobby-commands:1:1,bugout-game-lobby:1:1,bugout-choose-color-pref-cmd:1:1,bugout-session-game-ready-ev:1:1,bugout-game-color-pref-ev:1:1,bugout-colors-chosen-ev:1:1,bugout-client-heartbeat-ev:1:1,bugout-shutdown-ev:1:1,bugout-session-disconnected-ev:1:1,bugout-quit-cmd:1:1"
+      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1,bugout-provide-history-cmd:1:1,bugout-history-provided-ev:1:1,bugout-find-public-game-cmd:1:1,bugout-create-game-cmd:1:1,bugout-wait-for-opponent-ev:1:1,bugout-game-ready-ev:1:1,bugout-private-game-rejected-ev:1:1,bugout-join-private-game-cmd:1:1,bugout-game-lobby-commands:1:1,bugout-game-lobby:1:1,bugout-choose-color-pref-cmd:1:1,bugout-session-game-ready-ev:1:1,bugout-game-color-pref-ev:1:1,bugout-colors-chosen-ev:1:1,bugout-client-heartbeat-ev:1:1,bugout-shutdown-ev:1:1,bugout-session-disconnected-ev:1:1,bugout-quit-game-cmd:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/dc-giant.yml
+++ b/dc-giant.yml
@@ -16,7 +16,7 @@ services:
     environment:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${HOSTNAME}:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1,bugout-provide-history-cmd:1:1,bugout-history-provided-ev:1:1,bugout-find-public-game-cmd:1:1,bugout-create-game-cmd:1:1,bugout-wait-for-opponent-ev:1:1,bugout-game-ready-ev:1:1,bugout-private-game-rejected-ev:1:1,bugout-join-private-game-cmd:1:1,bugout-game-lobby-commands:1:1,bugout-game-lobby:1:1,bugout-choose-color-pref-cmd:1:1,bugout-session-game-ready-ev:1:1,bugout-game-color-pref-ev:1:1,bugout-colors-chosen-ev:1:1,bugout-client-heartbeat-ev:1:1,bugout-shutdown-ev:1:1,bugout-session-disconnected-ev:1:1"
+      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1,bugout-provide-history-cmd:1:1,bugout-history-provided-ev:1:1,bugout-find-public-game-cmd:1:1,bugout-create-game-cmd:1:1,bugout-wait-for-opponent-ev:1:1,bugout-game-ready-ev:1:1,bugout-private-game-rejected-ev:1:1,bugout-join-private-game-cmd:1:1,bugout-game-lobby-commands:1:1,bugout-game-lobby:1:1,bugout-choose-color-pref-cmd:1:1,bugout-session-game-ready-ev:1:1,bugout-game-color-pref-ev:1:1,bugout-colors-chosen-ev:1:1,bugout-client-heartbeat-ev:1:1,bugout-shutdown-ev:1:1,bugout-session-disconnected-ev:1:1,bugout-quit-cmd:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1,bugout-provide-history-cmd:1:1,bugout-history-provided-ev:1:1,bugout-find-public-game-cmd:1:1,bugout-create-game-cmd:1:1,bugout-wait-for-opponent-ev:1:1,bugout-game-ready-ev:1:1,bugout-private-game-rejected-ev:1:1,bugout-join-private-game-cmd:1:1,bugout-game-lobby-commands:1:1,bugout-game-lobby:1:1,bugout-choose-color-pref-cmd:1:1,bugout-session-game-ready-ev:1:1,bugout-game-color-pref-ev:1:1,bugout-colors-chosen-ev:1:1,bugout-client-heartbeat-ev:1:1,bugout-shutdown-ev:1:1,bugout-session-disconnected-ev:1:1"
+      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1,bugout-provide-history-cmd:1:1,bugout-history-provided-ev:1:1,bugout-find-public-game-cmd:1:1,bugout-create-game-cmd:1:1,bugout-wait-for-opponent-ev:1:1,bugout-game-ready-ev:1:1,bugout-private-game-rejected-ev:1:1,bugout-join-private-game-cmd:1:1,bugout-game-lobby-commands:1:1,bugout-game-lobby:1:1,bugout-choose-color-pref-cmd:1:1,bugout-session-game-ready-ev:1:1,bugout-game-color-pref-ev:1:1,bugout-colors-chosen-ev:1:1,bugout-client-heartbeat-ev:1:1,bugout-shutdown-ev:1:1,bugout-session-disconnected-ev:1:1,bugout-quit-cmd:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1,bugout-provide-history-cmd:1:1,bugout-history-provided-ev:1:1,bugout-find-public-game-cmd:1:1,bugout-create-game-cmd:1:1,bugout-wait-for-opponent-ev:1:1,bugout-game-ready-ev:1:1,bugout-private-game-rejected-ev:1:1,bugout-join-private-game-cmd:1:1,bugout-game-lobby-commands:1:1,bugout-game-lobby:1:1,bugout-choose-color-pref-cmd:1:1,bugout-session-game-ready-ev:1:1,bugout-game-color-pref-ev:1:1,bugout-colors-chosen-ev:1:1,bugout-client-heartbeat-ev:1:1,bugout-shutdown-ev:1:1,bugout-session-disconnected-ev:1:1,bugout-quit-cmd:1:1"
+      KAFKA_CREATE_TOPICS: "bugout-move-accepted-ev:1:1,bugout-move-made-ev:1:1,bugout-move-rejected-ev:1:1,bugout-make-move-cmd:1:1,bugout-game-states:1:1,bugout-provide-history-cmd:1:1,bugout-history-provided-ev:1:1,bugout-find-public-game-cmd:1:1,bugout-create-game-cmd:1:1,bugout-wait-for-opponent-ev:1:1,bugout-game-ready-ev:1:1,bugout-private-game-rejected-ev:1:1,bugout-join-private-game-cmd:1:1,bugout-game-lobby-commands:1:1,bugout-game-lobby:1:1,bugout-choose-color-pref-cmd:1:1,bugout-session-game-ready-ev:1:1,bugout-game-color-pref-ev:1:1,bugout-colors-chosen-ev:1:1,bugout-client-heartbeat-ev:1:1,bugout-shutdown-ev:1:1,bugout-session-disconnected-ev:1:1,bugout-quit-game-cmd:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -256,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gateway"
-version = "0.13.0"
+version = "0.12.1"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -256,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gateway"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "0.13.0"
+version = "0.12.1"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/gateway/src/client_commands.rs
+++ b/gateway/src/client_commands.rs
@@ -29,6 +29,12 @@ pub struct ChooseColorPrefClientCommand {
     pub color_pref: ColorPref,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct QuitClientCommand {
+    #[serde(rename = "gameId")]
+    pub game_id: GameId,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "type")]
 pub enum ClientCommands {
@@ -42,6 +48,7 @@ pub enum ClientCommands {
     ChooseColorPref(ChooseColorPrefClientCommand),
     ProvideIdleStatus,
     Identify(Identity),
+    Quit(QuitClientCommand),
 }
 
 #[cfg(test)]

--- a/gateway/src/client_commands.rs
+++ b/gateway/src/client_commands.rs
@@ -29,12 +29,6 @@ pub struct ChooseColorPrefClientCommand {
     pub color_pref: ColorPref,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct QuitClientCommand {
-    #[serde(rename = "gameId")]
-    pub game_id: GameId,
-}
-
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "type")]
 pub enum ClientCommands {
@@ -48,7 +42,7 @@ pub enum ClientCommands {
     ChooseColorPref(ChooseColorPrefClientCommand),
     ProvideIdleStatus,
     Identify(Identity),
-    Quit(QuitClientCommand),
+    QuitGame,
 }
 
 #[cfg(test)]

--- a/gateway/src/client_events.rs
+++ b/gateway/src/client_events.rs
@@ -18,6 +18,7 @@ pub enum ClientEvents {
     YourColor(YourColorEvent),
     IdleStatusProvided(IdleStatus),
     IdentityAcknowledged(Identity),
+    OpponentQuit,
 }
 
 impl ClientEvents {

--- a/gateway/src/kafka_commands.rs
+++ b/gateway/src/kafka_commands.rs
@@ -65,6 +65,14 @@ pub struct SessionDisconnected {
     pub session_id: SessionId,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct QuitCommand {
+    #[serde(rename = "clientId")]
+    pub client_id: ClientId,
+    #[serde(rename = "gameId")]
+    pub game_id: GameId,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub enum KafkaCommands {
     MakeMove(MakeMoveCommand),
@@ -75,4 +83,5 @@ pub enum KafkaCommands {
     ChooseColorPref(ChooseColorPrefKafkaCommand),
     ClientHeartbeat(ClientHeartbeat),
     SessionDisconnected(SessionDisconnected),
+    Quit(QuitCommand),
 }

--- a/gateway/src/kafka_commands.rs
+++ b/gateway/src/kafka_commands.rs
@@ -66,7 +66,7 @@ pub struct SessionDisconnected {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct QuitCommand {
+pub struct QuitGameCommand {
     #[serde(rename = "clientId")]
     pub client_id: ClientId,
     #[serde(rename = "gameId")]
@@ -83,5 +83,5 @@ pub enum KafkaCommands {
     ChooseColorPref(ChooseColorPrefKafkaCommand),
     ClientHeartbeat(ClientHeartbeat),
     SessionDisconnected(SessionDisconnected),
-    Quit(QuitCommand),
+    QuitGame(QuitGameCommand),
 }

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -70,7 +70,7 @@ fn start_producer(kafka_out: crossbeam::Receiver<KafkaCommands>) {
                     Ok(KafkaCommands::SessionDisconnected(c)) =>
                         write(&producer, SESSION_DISCONNECTED_TOPIC, &serde_json::to_string(&c), &c.session_id.to_string())
                     ,
-                    Ok(KafkaCommands::Quit(_q)) => unimplemented!(),
+                    Ok(KafkaCommands::Quit(_q)) => todo!(),
                     Err(e) => println!("💩 Unable to receive command via kafka channel: {:?}", e),
                 }
         }

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -70,6 +70,7 @@ fn start_producer(kafka_out: crossbeam::Receiver<KafkaCommands>) {
                     Ok(KafkaCommands::SessionDisconnected(c)) =>
                         write(&producer, SESSION_DISCONNECTED_TOPIC, &serde_json::to_string(&c), &c.session_id.to_string())
                     ,
+                    Ok(KafkaCommands::Quit(_q)) => unimplemented!(),
                     Err(e) => println!("💩 Unable to receive command via kafka channel: {:?}", e),
                 }
         }

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -70,8 +70,11 @@ fn start_producer(kafka_out: crossbeam::Receiver<KafkaCommands>) {
                     Ok(KafkaCommands::SessionDisconnected(c)) =>
                         write(&producer, SESSION_DISCONNECTED_TOPIC, &serde_json::to_string(&c), &c.session_id.to_string())
                     ,
-                    Ok(KafkaCommands::Quit(_q)) => todo!(),
-                    Err(e) => println!("💩 Unable to receive command via kafka channel: {:?}", e),
+                    Ok(KafkaCommands::Quit(q)) =>
+                        write(&producer, QUIT_GAME_TOPIC, &serde_json::to_string(&q), &q.game_id.to_string())
+                    ,
+                    Err(e) => println!("💩 Unable to receive command via kafka channel: {:?}", e)
+                    ,
                 }
         }
     }

--- a/gateway/src/kafka_io.rs
+++ b/gateway/src/kafka_io.rs
@@ -70,7 +70,7 @@ fn start_producer(kafka_out: crossbeam::Receiver<KafkaCommands>) {
                     Ok(KafkaCommands::SessionDisconnected(c)) =>
                         write(&producer, SESSION_DISCONNECTED_TOPIC, &serde_json::to_string(&c), &c.session_id.to_string())
                     ,
-                    Ok(KafkaCommands::Quit(q)) =>
+                    Ok(KafkaCommands::QuitGame(q)) =>
                         write(&producer, QUIT_GAME_TOPIC, &serde_json::to_string(&q), &q.game_id.to_string())
                     ,
                     Err(e) => println!("💩 Unable to receive command via kafka channel: {:?}", e)

--- a/gateway/src/topics.rs
+++ b/gateway/src/topics.rs
@@ -4,6 +4,7 @@ pub const JOIN_PRIVATE_GAME_TOPIC: &str = "bugout-join-private-game-cmd";
 pub const FIND_PUBLIC_GAME_TOPIC: &str = "bugout-find-public-game-cmd";
 pub const CREATE_GAME_TOPIC: &str = "bugout-create-game-cmd";
 pub const CHOOSE_COLOR_PREF_TOPIC: &str = "bugout-choose-color-pref-cmd";
+pub const QUIT_GAME_TOPIC: &str = "bugout-quit-game-cmd";
 
 pub const MOVE_MADE_TOPIC: &str = "bugout-move-made-ev";
 pub const HISTORY_PROVIDED_TOPIC: &str = "bugout-history-provided-ev";

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -347,6 +347,8 @@ impl Handler for WsSession {
             }
             Ok(ClientCommands::QuitGame) => {
                 if let (Some(client_id), Some(game_id)) = (self.client_id, self.current_game) {
+                    println!("🏳️ {} {:<8}", session_code(self), "QUITGAME");
+
                     let s = KafkaCommands::QuitGame(QuitGameCommand { client_id, game_id });
                     self.kafka_commands_in
                         .send(s)
@@ -458,13 +460,13 @@ impl Handler for WsSession {
                                 game_id: _,
                                 your_color,
                             }) if your_color == Player::BLACK => {
-                                println!("🏴 {} {:<8} Black", session_code(self), "YOURCOLR")
+                                println!("⚫️ {} {:<8} Black", session_code(self), "YOURCOLR")
                             }
                             ClientEvents::YourColor(YourColorEvent {
                                 game_id: _,
                                 your_color,
                             }) if your_color == Player::WHITE => {
-                                println!("🏳  {} {:<8} White", session_code(self), "YOURCOLR")
+                                println!("⚪️ {} {:<8} White", session_code(self), "YOURCOLR")
                             }
                             _ => (),
                         }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -345,7 +345,17 @@ impl Handler for WsSession {
                         )
                     })
             }
-            Ok(ClientCommands::Quit(_q)) => todo!(),
+            Ok(ClientCommands::QuitGame) => {
+                if let (Some(client_id), Some(game_id)) = (self.client_id, self.current_game) {
+                    let s = KafkaCommands::QuitGame(QuitGameCommand { client_id, game_id });
+                    self.kafka_commands_in
+                        .send(s)
+                        .map_err(|e| ws::Error::from(Box::new(e)))
+                } else {
+                    println!("Can't quit without client ID + game ID");
+                    Ok(())
+                }
+            }
             Err(_err) => {
                 println!(
                     "💥 {} {:<8} message deserialization {}",

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -347,7 +347,16 @@ impl Handler for WsSession {
             }
             Ok(ClientCommands::QuitGame) => {
                 if let (Some(client_id), Some(game_id)) = (self.client_id, self.current_game) {
-                    println!("🏳️ {} {:<8}", session_code(self), "QUITGAME");
+                    println!("🏳️  {} {:<8}", session_code(self), "QUITGAME");
+
+                    self.current_game = None;
+
+                    if let Err(e) = self.router_commands_in.send(RouterCommand::QuitGame {
+                        session_id: self.session_id,
+                        game_id,
+                    }) {
+                        println!("ERROR SENDING ROUTER QUIT COMMAND: {}", e);
+                    }
 
                     let s = KafkaCommands::QuitGame(QuitGameCommand { client_id, game_id });
                     self.kafka_commands_in
@@ -467,6 +476,9 @@ impl Handler for WsSession {
                                 your_color,
                             }) if your_color == Player::WHITE => {
                                 println!("⚪️ {} {:<8} White", session_code(self), "YOURCOLR")
+                            }
+                            ClientEvents::OpponentQuit => {
+                                self.current_game = None;
                             }
                             _ => (),
                         }

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -345,6 +345,7 @@ impl Handler for WsSession {
                         )
                     })
             }
+            Ok(ClientCommands::Quit(_q)) => todo!(),
             Err(_err) => {
                 println!(
                     "💥 {} {:<8} message deserialization {}",


### PR DESCRIPTION
Allow Sabaki to send a `{ "type": "QuitGame" }` command, which is forwarded to a related kafka topic.

Advances #153.
