### PR TITLE
Relocate function

### DIFF
--- a/micro-judge/Cargo.lock
+++ b/micro-judge/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "micro_model_moves"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "serde",

--- a/micro-judge/Cargo.lock
+++ b/micro-judge/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
 
 [[package]]
 name = "micro-judge"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "micro_model_moves",

--- a/micro-judge/Cargo.toml
+++ b/micro-judge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-judge"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 

--- a/micro-model/moves/Cargo.lock
+++ b/micro-model/moves/Cargo.lock
@@ -44,7 +44,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "micro_model_moves"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/micro-model/moves/Cargo.toml
+++ b/micro-model/moves/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro_model_moves"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 

--- a/micro-model/moves/src/lib.rs
+++ b/micro-model/moves/src/lib.rs
@@ -1,6 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::str::FromStr;
 use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Eq)]
@@ -48,28 +47,6 @@ pub struct MakeMoveCommand {
     pub coord: Option<Coord>,
 }
 
-pub struct ModelDeserErr;
-
-impl MakeMoveCommand {
-    pub fn from(xread_result: HashMap<String, String>) -> Result<MakeMoveCommand, uuid::Error> {
-        let mx: Option<u16> = xread_result
-            .get("coord_x")
-            .and_then(|s| s.parse::<u16>().ok());
-        let my: Option<u16> = xread_result
-            .get("coord_y")
-            .and_then(|s| s.parse::<u16>().ok());
-        let coord = match (mx, my) {
-            (Some(x), Some(y)) => Some(Coord { x, y }),
-            _ => None,
-        };
-        Ok(MakeMoveCommand {
-            game_id: GameId(Uuid::from_str(&xread_result["game_id"])?),
-            req_id: ReqId(Uuid::from_str(&xread_result["req_id"])?),
-            player: Player::from_str(&xread_result["player"]),
-            coord,
-        })
-    }
-}
 #[derive(Debug, Clone, PartialEq, Copy, Eq, Hash, Serialize, Deserialize)]
 pub struct Coord {
     pub x: u16,
@@ -172,7 +149,7 @@ mod tests {
             captured: vec![],
             event_id: EventId::new(),
             game_id: GameId(Uuid::new_v4()),
-            reply_to: ReqId(Uuid::new_v4())
+            reply_to: ReqId(Uuid::new_v4()),
         });
         let bytes = gs.serialize().unwrap();
         let back = GameState::from(&bytes).unwrap();


### PR DESCRIPTION
Refactors the location of a function nearer to its call site.  This deserialization will only be needed by micro-judge.