### PR TITLE
Clean up tinybrain REPL

### DIFF
--- a/tinybrain/Cargo.lock
+++ b/tinybrain/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "tinybrain"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.12.0",
  "bincode",

--- a/tinybrain/Cargo.toml
+++ b/tinybrain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinybrain"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 

--- a/tinybrain/examples/repl.rs
+++ b/tinybrain/examples/repl.rs
@@ -32,13 +32,13 @@ fn main() {
     for stream in server.incoming() {
         spawn(move || {
             let callback = |_: &Request, response: Response| {
-                info!("# Received WS handshake");
+                info!("Received WS handshake");
                 Ok(response)
             };
             let mut websocket = accept_hdr(stream.unwrap(), callback).unwrap();
 
             let size = 9;
-            info!("# Board size {}x{}", size, size);
+            info!("Board size {}x{}", size, size);
 
             let game_state = &mut GameState {
                 board: Board {
@@ -61,7 +61,7 @@ fn main() {
                 let happy_coord = json::interpret_coord(&line);
                 match happy_coord {
                     Err(_) => {
-                        error!("! parse error");
+                        error!("parse error");
                         continue;
                     }
                     Ok(coord) => {
@@ -89,7 +89,7 @@ fn main() {
                                 .expect("ser"),
                             ))
                             .unwrap();
-                        info!(".");
+                        info!("(...waiting for katago...)");
 
                         // block
                         match websocket.read_message().unwrap() {

--- a/tinybrain/examples/repl.rs
+++ b/tinybrain/examples/repl.rs
@@ -52,7 +52,7 @@ fn main() {
             let game_id = &GameId(Uuid::new_v4());
 
             loop {
-                info!("< B");
+                print!("< B");
                 let line: String = read!("{}\n");
                 let happy_coord = json::interpret_coord(&line);
                 match happy_coord {

--- a/tinybrain/examples/repl.rs
+++ b/tinybrain/examples/repl.rs
@@ -12,7 +12,7 @@ extern crate uuid;
 use micro_model_moves::*;
 
 use log::{error, info, trace};
-use std::io::{self, Write};
+use std::io::Write;
 use std::net::TcpListener;
 use std::thread::spawn;
 use text_io::read;
@@ -53,7 +53,7 @@ fn main() {
             let game_id = &GameId(Uuid::new_v4());
 
             loop {
-                print!("< B");
+                print!("< B ");
                 if let Err(e) = std::io::stdout().flush() {
                     error!("{}", e)
                 };
@@ -99,7 +99,7 @@ fn main() {
                                 let last_move = move_computed.0;
                                 let mmm = json::Move::from(last_move.player, last_move.coord)
                                     .expect("boom");
-                                info!("> {} {}", mmm.0, (mmm.1).0);
+                                println!("> {} {}", mmm.0, (mmm.1).0);
 
                                 game_state.moves.push(MoveMade {
                                     coord: last_move.coord,

--- a/tinybrain/examples/repl.rs
+++ b/tinybrain/examples/repl.rs
@@ -12,6 +12,7 @@ extern crate uuid;
 use micro_model_moves::*;
 
 use log::{error, info, trace};
+use std::io::{self, Write};
 use std::net::TcpListener;
 use std::thread::spawn;
 use text_io::read;
@@ -53,6 +54,9 @@ fn main() {
 
             loop {
                 print!("< B");
+                if let Err(e) = std::io::stdout().flush() {
+                    error!("{}", e)
+                };
                 let line: String = read!("{}\n");
                 let happy_coord = json::interpret_coord(&line);
                 match happy_coord {


### PR DESCRIPTION
Flushes the tinybrain REPL example's stdout and removes a couple of invocations of `log::info` in favor of `print`.

Advances #67.