### PR TITLE
Gateway: support bot attachment

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -352,8 +352,9 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
+ "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -370,6 +371,7 @@ dependencies = [
  "r2d2_redis 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis_streams 0.1.0 (git+https://github.com/Terkwood/BUGOUT?branch=unstable)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -522,7 +524,7 @@ dependencies = [
 [[package]]
 name = "micro_model_bot"
 version = "0.1.1"
-source = "git+https://github.com/Terkwood/BUGOUT?branch=unstable#0d0bd72a15a4d2506a0cf4a14b620ffb9a207724"
+source = "git+https://github.com/Terkwood/BUGOUT?branch=unstable#574ac7d43cc4f5fc3d8d3ab0cff81df1c57a2c75"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "micro_model_moves 0.1.2 (git+https://github.com/Terkwood/BUGOUT?branch=unstable)",
@@ -533,7 +535,7 @@ dependencies = [
 [[package]]
 name = "micro_model_moves"
 version = "0.1.2"
-source = "git+https://github.com/Terkwood/BUGOUT?branch=unstable#0d0bd72a15a4d2506a0cf4a14b620ffb9a207724"
+source = "git+https://github.com/Terkwood/BUGOUT?branch=unstable#574ac7d43cc4f5fc3d8d3ab0cff81df1c57a2c75"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -857,6 +859,14 @@ dependencies = [
  "tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redis_streams"
+version = "0.1.0"
+source = "git+https://github.com/Terkwood/BUGOUT?branch=unstable#574ac7d43cc4f5fc3d8d3ab0cff81df1c57a2c75"
+dependencies = [
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1342,6 +1352,7 @@ dependencies = [
 "checksum rdkafka 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d455ac2a07a27d87b4f0e321dfd8d9a5b574bd96f55e42e6c594712a08051222"
 "checksum rdkafka-sys 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d770343fbbc6089c750000711a17a906e8b3f7831afcd752d9667d38833e578"
 "checksum redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bb1079bc5692c03e1479bb7086ac870ac2aaf7115b5e72d314c01368f1a747e"
+"checksum redis_streams 0.1.0 (git+https://github.com/Terkwood/BUGOUT?branch=unstable)" = "<none>"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "gateway"
-version = "0.12.4"
+version = "0.13.0"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
+micro_model_moves = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
+micro_model_bot = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
+redis_streams = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
+chrono = { version = "0.4.10", features = ["serde"] }
+uuid = { version = "0.8.1", features = ["v4", "serde"] }
 crossbeam = "0.7.3"
 crossbeam-channel = "0.4.0"
 mio-extras = "2.0.6"
@@ -14,19 +19,16 @@ serde = "1.0.106"
 serde_derive = "1.0.106"
 serde_json = "1.0.44"
 time = "0.1.42"
-uuid = { version = "0.8.1", features = ["v4", "serde"] }
 ws = "0.9.1"
 harsh = "0.1.6"
 lazy_static = "1.4.0"
 envy = "0.4.0"
 dotenv = "0.15.0"
 futures = "0.3.0"
-chrono = { version = "0.4.10", features = ["serde"] }
 r2d2_redis = "0.12.0"
 log = "0.4.8"
 env_logger = "0.7.1"
-micro_model_moves = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
-micro_model_bot = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
+bincode = "1.2.1"
 
 [dev-dependencies]
 rand = "0.7.2"

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,29 +1,30 @@
 FROM rust
 
+RUN apt-get update -y 
+RUN apt-get install -y clang
+
+RUN rustup default stable   
+
 WORKDIR /var/
-# git clone to support the librdkafka submodule
+
+# supports the librdkafka submodule
 RUN git clone https://github.com/Terkwood/BUGOUT
 WORKDIR /var/BUGOUT/gateway
 RUN git submodule update --init
 
-RUN apt-get update -y 
-RUN apt-get install -y clang
-
-# optional: useful for wait-run.sh
-RUN curl -O https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
-RUN chmod 755 wait-for-it.sh
-
 RUN git fetch && git pull
 RUN git rev-parse HEAD
-
-RUN rustup default stable   
 
 # make sure we have the most recent of everything,
 # not just what's on the git branch
 COPY . /var/BUGOUT/gateway/.
 
-RUN cargo install --path .
+#TODO
+#RUN cargo install --path .
 
 ENV RUST_LOG info
 
-CMD ["gateway"]
+### TODO
+# CMD ["gateway"]
+### TODO
+CMD ["tail","-f","/dev/null"] 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -19,12 +19,8 @@ RUN git rev-parse HEAD
 # not just what's on the git branch
 COPY . /var/BUGOUT/gateway/.
 
-#TODO
-#RUN cargo install --path .
+RUN cargo install --path .
 
 ENV RUST_LOG info
 
-### TODO
-# CMD ["gateway"]
-### TODO
-CMD ["tail","-f","/dev/null"] 
+CMD ["gateway"]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -13,6 +13,7 @@ extern crate micro_model_moves;
 extern crate mio_extras;
 extern crate r2d2_redis;
 extern crate rand;
+extern crate redis_streams;
 extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -31,7 +31,7 @@ impl Player {
             Player::BLACK => Player::WHITE,
             Player::WHITE => Player::BLACK,
         }
-    }  
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]

--- a/gateway/src/redis_io/entry_id_repo.rs
+++ b/gateway/src/redis_io/entry_id_repo.rs
@@ -1,1 +1,88 @@
-pub trait EntryIdRepo {}
+use super::AllEntryIds;
+use super::RedisPool;
+use redis_streams::XReadEntryId;
+
+use r2d2_redis::redis;
+use redis::Commands;
+use std::collections::HashMap;
+
+pub trait EntryIdRepo {
+    fn fetch_all(&self) -> Result<AllEntryIds, EidRepoErr>;
+
+    fn update(&self, entry_id_type: EntryIdType, entry_id: XReadEntryId) -> Result<(), EidRepoErr>;
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum EntryIdType {
+    BotAttached,
+    MoveMade,
+}
+impl EntryIdType {
+    pub fn hash_field(&self) -> String {
+        match self {
+            EntryIdType::BotAttached => BOT_ATTACHED_EID.to_string(),
+            EntryIdType::MoveMade => MOVE_MADE_EID.to_string(),
+        }
+    }
+}
+#[derive(Debug)]
+pub enum EidRepoErr {
+    Redis(redis::RedisError),
+}
+impl From<redis::RedisError> for EidRepoErr {
+    fn from(r: redis::RedisError) -> Self {
+        EidRepoErr::Redis(r)
+    }
+}
+
+pub struct RedisEntryIdRepo {
+    pool: RedisPool,
+
+    pub key_provider: super::KeyProvider,
+}
+
+const EMPTY_EID: &str = "0-0";
+const MOVE_MADE_EID: &str = "move_made_eid";
+const BOT_ATTACHED_EID: &str = "bot_attached_eid";
+
+impl EntryIdRepo for RedisEntryIdRepo {
+    fn fetch_all(&self) -> Result<AllEntryIds, EidRepoErr> {
+        let mut conn = self.pool.get().expect("pool");
+        let found: Result<HashMap<String, String>, _> = conn.hgetall(self.key_provider.entry_ids());
+        let f = found?;
+        let bot_attached_eid = XReadEntryId::from_str(
+            &f.get(BOT_ATTACHED_EID)
+                .unwrap_or(&EMPTY_EID.to_string())
+                .to_string(),
+        )
+        .unwrap_or(XReadEntryId::default());
+        let move_made_eid = XReadEntryId::from_str(
+            &f.get(MOVE_MADE_EID)
+                .unwrap_or(&EMPTY_EID.to_string())
+                .to_string(),
+        )
+        .unwrap_or(XReadEntryId::default());
+        Ok(AllEntryIds {
+            bot_attached_eid,
+            move_made_eid,
+        })
+    }
+
+    fn update(&self, entry_id_type: EntryIdType, entry_id: XReadEntryId) -> Result<(), EidRepoErr> {
+        let mut conn = self.pool.get().expect("redis pool");
+        Ok(conn.hset(
+            self.key_provider.entry_ids(),
+            entry_id_type.hash_field(),
+            entry_id.to_string(),
+        )?)
+    }
+}
+
+impl RedisEntryIdRepo {
+    pub fn create_boxed() -> Box<dyn EntryIdRepo> {
+        Box::new(RedisEntryIdRepo {
+            pool: super::create_pool(),
+            key_provider: super::KeyProvider::default(),
+        })
+    }
+}

--- a/gateway/src/redis_io/mod.rs
+++ b/gateway/src/redis_io/mod.rs
@@ -3,12 +3,14 @@ mod key_provider;
 mod namespace;
 pub mod stream;
 pub mod xadd;
+pub mod xread;
 
 pub use key_provider::*;
 pub use namespace::*;
-pub use xadd::xadd_commands;
+pub use xadd::start;
 
 use r2d2_redis::{r2d2, RedisConnectionManager};
+use redis_streams::XReadEntryId;
 
 pub type RedisPool = r2d2_redis::r2d2::Pool<r2d2_redis::RedisConnectionManager>;
 
@@ -17,4 +19,10 @@ pub const REDIS_URL: &str = "redis://redis";
 pub fn create_pool() -> RedisPool {
     let manager = RedisConnectionManager::new(REDIS_URL).unwrap();
     r2d2::Pool::builder().build(manager).unwrap()
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct AllEntryIds {
+    pub bot_attached_eid: XReadEntryId,
+    pub move_made_eid: XReadEntryId,
 }

--- a/gateway/src/redis_io/stream.rs
+++ b/gateway/src/redis_io/stream.rs
@@ -4,7 +4,7 @@ use crate::backend_events::BackendEvents;
 use crate::model::{Coord, MoveMadeEvent, Player};
 
 use crossbeam_channel::Sender;
-use log::{info,error};
+use log::{error, info};
 
 pub fn process(events_in: Sender<BackendEvents>, opts: StreamOpts) {
     loop {

--- a/gateway/src/redis_io/stream.rs
+++ b/gateway/src/redis_io/stream.rs
@@ -1,7 +1,85 @@
+use super::entry_id_repo::*;
+use super::xread::XReader;
 use crate::backend_events::BackendEvents;
-use crossbeam_channel::Sender;
-use log::warn;
+use crate::model::{Coord, MoveMadeEvent, Player};
 
-pub fn process(_events_in: Sender<BackendEvents>) {
-    warn!("Stream processing unimplemented")
+use crossbeam_channel::Sender;
+use log::{info,error};
+
+pub fn process(events_in: Sender<BackendEvents>, opts: StreamOpts) {
+    loop {
+        match opts.entry_id_repo.fetch_all() {
+            Err(e) => error!("cannot fetch entry id repo {:?}", e),
+            Ok(entry_ids) => match opts.xreader.xread_sorted(entry_ids) {
+                Err(e) => error!("cannot xread {:?}", e),
+                Ok(xrr) => {
+                    for event in xrr {
+                        match event {
+                            (entry_id, StreamData::BotAttached(b)) => {
+                                if let Err(e) = events_in.send(BackendEvents::BotAttached(b)) {
+                                    error!("send err bot attached {:?}", e)
+                                } else {
+                                    if let Err(e) = opts
+                                        .entry_id_repo
+                                        .update(EntryIdType::BotAttached, entry_id)
+                                    {
+                                        error!("err tracking EID bot attached {:?}", e)
+                                    }
+                                }
+                            }
+                            (
+                                entry_id,
+                                StreamData::MoveMade(micro_model_moves::MoveMade {
+                                    game_id,
+                                    coord,
+                                    reply_to,
+                                    player,
+                                    captured,
+                                    event_id,
+                                }),
+                            ) => {
+                                if let Err(e) =
+                                    events_in.send(BackendEvents::MoveMade(MoveMadeEvent {
+                                        game_id: game_id.0,
+                                        coord: coord.map(|c| Coord { x: c.x, y: c.y }),
+                                        reply_to: reply_to.0,
+                                        player: match player {
+                                            micro_model_moves::Player::BLACK => Player::BLACK,
+                                            _ => Player::WHITE,
+                                        },
+                                        captured: captured
+                                            .iter()
+                                            .map(|c| Coord { x: c.x, y: c.y })
+                                            .collect(),
+                                        event_id: event_id.0,
+                                    }))
+                                {
+                                    error!("send err move made {:?}", e)
+                                } else {
+                                    info!("sent move made backend event in channel")
+                                }
+
+                                if let Err(e) =
+                                    opts.entry_id_repo.update(EntryIdType::MoveMade, entry_id)
+                                {
+                                    error!("err tracking EID move made {:?}", e)
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+    }
+}
+
+pub struct StreamOpts {
+    pub entry_id_repo: Box<dyn EntryIdRepo>,
+    pub xreader: Box<dyn XReader>,
+}
+
+#[derive(Clone, Debug)]
+pub enum StreamData {
+    BotAttached(micro_model_bot::gateway::BotAttached),
+    MoveMade(micro_model_moves::MoveMade),
 }

--- a/gateway/src/redis_io/xadd.rs
+++ b/gateway/src/redis_io/xadd.rs
@@ -5,7 +5,7 @@ use crate::topics::{ATTACH_BOT_TOPIC, MAKE_MOVE_TOPIC};
 use micro_model_bot::gateway::AttachBot;
 
 use crossbeam_channel::{select, Receiver};
-use log::{error,info};
+use log::{error, info};
 use r2d2_redis::redis;
 
 pub trait XAddCommands {

--- a/gateway/src/redis_io/xadd.rs
+++ b/gateway/src/redis_io/xadd.rs
@@ -1,25 +1,152 @@
 use crate::backend_commands::BackendCommands;
+use crate::model::{Coord, MakeMoveCommand};
 use crate::redis_io::RedisPool;
+use crate::topics::{ATTACH_BOT_TOPIC, MAKE_MOVE_TOPIC};
+use micro_model_bot::gateway::AttachBot;
 
 use crossbeam_channel::{select, Receiver};
-use log::{error, warn};
+use log::{error,info};
+use r2d2_redis::redis;
 
-pub fn xadd_commands(commands_in: Receiver<BackendCommands>, _pool: &RedisPool) {
+pub trait XAddCommands {
+    fn xadd_attach_bot(&self, attach_bot: AttachBot);
+    fn xadd_make_move(&self, command: MakeMoveCommand);
+}
+
+pub fn start(commands_out: Receiver<BackendCommands>, cmds: &dyn XAddCommands) {
     loop {
         select! {
-            recv(commands_in) -> backend_command_msg => match backend_command_msg {
+            recv(commands_out) -> backend_command_msg => match backend_command_msg {
                 Err(e) => error!("backend command xadd {:?}",e),
-                Ok(command) => xadd(command)
+                Ok(command) => match command {
+                    BackendCommands::AttachBot(attach_bot) => {
+                        cmds.xadd_attach_bot(attach_bot)
+                    }
+                    BackendCommands::MakeMove(c) => cmds.xadd_make_move(c),
+                    BackendCommands::ClientHeartbeat(_) => (),
+                    _ => error!("cannot match backend command to xadd"),
+                }
             }
         }
     }
 }
 
-fn xadd(command: BackendCommands) {
-    match command {
-        BackendCommands::AttachBot(ab_cmd) => {
-            warn!("Failed to match attach bot command : {:?}", ab_cmd)
+pub struct RedisXAddCommands {
+    pub pool: RedisPool,
+}
+
+impl XAddCommands for RedisXAddCommands {
+    fn xadd_attach_bot(&self, attach_bot: AttachBot) {
+        let mut conn = self.pool.get().unwrap();
+
+        match attach_bot.serialize() {
+            Err(e) => error!("attach bot ser error {:?}", e),
+            Ok(bin) => {
+                info!("xadd to {}", ATTACH_BOT_TOPIC); // TODO trim
+                let mut redis_cmd = redis::cmd("XADD");
+                redis_cmd
+                    .arg(ATTACH_BOT_TOPIC)
+                    .arg("MAXLEN")
+                    .arg("~")
+                    .arg("1000")
+                    .arg("*")
+                    .arg("data")
+                    .arg(bin);
+                if let Err(e) = redis_cmd.query::<String>(&mut *conn) {
+                    error!("attach bot redis err {:?}", e)
+                }
+            }
         }
-        _ => error!("match"),
+    }
+    fn xadd_make_move(&self, command: MakeMoveCommand) {
+        let mut conn = self.pool.get().unwrap();
+
+        let mut redis_cmd = redis::cmd("XADD");
+        redis_cmd
+            .arg(MAKE_MOVE_TOPIC)
+            .arg("MAXLEN")
+            .arg("~")
+            .arg("1000")
+            .arg("*")
+            .arg("game_id")
+            .arg(command.game_id.to_string())
+            .arg("player")
+            .arg(command.player.to_string())
+            .arg("req_id")
+            .arg(command.req_id.to_string());
+        if let Some(Coord { x, y }) = command.coord {
+            redis_cmd.arg("coord_x").arg(x).arg("coord_y").arg(y);
+        }
+        if let Err(e) = redis_cmd.query::<String>(&mut *conn) {
+            error!("make move {:?}", e)
+        }
+    }
+}
+
+impl RedisXAddCommands {
+    pub fn create() -> Self {
+        RedisXAddCommands {
+            pool: crate::redis_io::create_pool(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::*;
+
+    use crossbeam_channel::{select, unbounded, Receiver, Sender};
+    use std::thread;
+    use uuid::Uuid;
+
+    struct FakeXAddCmd {
+        st: Sender<TestResult>,
+    }
+    enum TestResult {
+        Bot(AttachBot),
+        Move(MakeMoveCommand),
+    }
+    impl XAddCommands for FakeXAddCmd {
+        fn xadd_attach_bot(&self, attach_bot: AttachBot) {
+            self.st.send(TestResult::Bot(attach_bot)).expect("send")
+        }
+        fn xadd_make_move(&self, command: MakeMoveCommand) {
+            self.st.send(TestResult::Move(command)).expect("send")
+        }
+    }
+
+    #[test]
+    fn test_loop() {
+        let (test_in, test_out): (Sender<TestResult>, Receiver<TestResult>) = unbounded();
+        let (cmds_in, cmds_out): (Sender<BackendCommands>, Receiver<BackendCommands>) = unbounded();
+
+        thread::spawn(move || start(cmds_out, &FakeXAddCmd { st: test_in }));
+
+        cmds_in
+            .send(BackendCommands::AttachBot(AttachBot {
+                game_id: micro_model_moves::GameId(Uuid::nil()),
+                board_size: Some(9),
+                player: micro_model_moves::Player::WHITE,
+            }))
+            .expect("send test");
+
+        cmds_in
+            .send(BackendCommands::MakeMove(MakeMoveCommand {
+                game_id: Uuid::nil(),
+                req_id: Uuid::nil(),
+                player: Player::BLACK,
+                coord: Some(Coord { x: 0, y: 0 }),
+            }))
+            .expect("send move test");
+
+        select! { recv(test_out) -> msg => match msg.expect("test out 0 ") {
+            TestResult::Bot(_) => assert!(true),
+            _ => assert!(false)
+        } }
+        select! { recv(test_out) -> msg => match msg.expect("test out 1 ") {
+            TestResult::Move(_) => assert!(true),
+            _ => assert!(false)
+        } }
     }
 }

--- a/gateway/src/redis_io/xread.rs
+++ b/gateway/src/redis_io/xread.rs
@@ -1,0 +1,113 @@
+use super::stream::StreamData;
+use crate::topics::{BOT_ATTACHED_TOPIC, MOVE_MADE_TOPIC};
+use redis_streams::XReadEntryId;
+
+use log::{error, warn};
+use r2d2_redis::redis;
+use std::collections::HashMap;
+use std::str::FromStr;
+use uuid::Uuid;
+
+/// performs a redis xread then sorts the results
+///
+/// entry_ids: the minimum entry ids from which to read
+pub trait XReader {
+    fn xread_sorted(
+        &self,
+        entry_ids: super::AllEntryIds,
+    ) -> Result<Vec<(XReadEntryId, StreamData)>, redis::RedisError>;
+}
+
+const BLOCK_MSEC: u32 = 5000;
+
+pub type XReadResult = Vec<HashMap<String, Vec<HashMap<String, redis::Value>>>>;
+
+pub struct RedisXReader {
+    pub pool: super::RedisPool,
+}
+impl XReader for RedisXReader {
+    fn xread_sorted(
+        &self,
+        entry_ids: super::AllEntryIds,
+    ) -> Result<std::vec::Vec<(XReadEntryId, StreamData)>, redis::RedisError> {
+        let mut conn = self.pool.get().unwrap();
+        let xrr = redis::cmd("XREAD")
+            .arg("BLOCK")
+            .arg(&BLOCK_MSEC.to_string())
+            .arg("STREAMS")
+            .arg(BOT_ATTACHED_TOPIC)
+            .arg(MOVE_MADE_TOPIC)
+            .arg(entry_ids.bot_attached_eid.to_string())
+            .arg(entry_ids.move_made_eid.to_string())
+            .query::<XReadResult>(&mut *conn)?;
+        let unsorted: HashMap<XReadEntryId, StreamData> = deser(xrr);
+        let sorted_keys: Vec<XReadEntryId> = {
+            let mut ks: Vec<XReadEntryId> = unsorted.keys().map(|k| *k).collect();
+            ks.sort();
+            ks
+        };
+        let mut answer: Vec<(XReadEntryId, StreamData)> = vec![];
+        for sk in sorted_keys {
+            if let Some(data) = unsorted.get(&sk) {
+                answer.push((sk, data.clone()))
+            }
+        }
+        Ok(answer)
+    }
+}
+
+fn deser(xread_result: XReadResult) -> HashMap<XReadEntryId, StreamData> {
+    let mut stream_data = HashMap::new();
+
+    for hash in xread_result.iter() {
+        for (xread_topic, xread_data) in hash.iter() {
+            if &xread_topic[..] == BOT_ATTACHED_TOPIC {
+                for with_timestamps in xread_data {
+                    for (k, v) in with_timestamps {
+                        let shape: Result<(String, Option<Vec<u8>>), _> = // data <bin> 
+                            redis::FromRedisValue::from_redis_value(&v);
+                        if let Ok(s) = shape {
+                            if let (Ok(seq_no), Some(bot_attached)) = (
+                                XReadEntryId::from_str(k),
+                                s.1.clone().and_then(|bytes| {
+                                    micro_model_bot::gateway::BotAttached::from(&bytes).ok()
+                                }),
+                            ) {
+                                stream_data.insert(seq_no, StreamData::BotAttached(bot_attached));
+                            } else {
+                                warn!("Xread: Deser error   bot attached data")
+                            }
+                        } else {
+                            warn!("Fail XREAD")
+                        }
+                    }
+                }
+            } else if &xread_topic[..] == MOVE_MADE_TOPIC {
+                for with_timestamps in xread_data {
+                    for (k, v) in with_timestamps {
+                        let shape: Result<(String, String, String, Vec<u8>), _> = // game_id <uuid-str> data <bin>
+                            redis::FromRedisValue::from_redis_value(&v);
+                        if let Ok(s) = shape {
+                            if let (Ok(seq_no), Some(_game_id), Some(move_made)) = (
+                                XReadEntryId::from_str(k),
+                                Uuid::from_str(&s.1).ok(),
+                                bincode::deserialize::<micro_model_moves::MoveMade>(&s.3.clone())
+                                    .ok(),
+                            ) {
+                                stream_data.insert(seq_no, StreamData::MoveMade(move_made));
+                            } else {
+                                error!("fail  move made xread inner")
+                            }
+                        } else {
+                            error!("Fail move made XREAD outer")
+                        }
+                    }
+                }
+            } else {
+                warn!("Ignoring topic {}", &xread_topic[..])
+            }
+        }
+    }
+
+    stream_data
+}

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -1,11 +1,10 @@
+use crossbeam::{Receiver, Sender};
+use crossbeam_channel::select;
+use log::{error, info};
 use std::collections::HashMap;
 use std::ops::Add;
 use std::thread;
 use std::time::{Duration, Instant};
-
-use crossbeam::{Receiver, Sender};
-use crossbeam_channel::select;
-
 use uuid::Uuid;
 
 use crate::backend_events::BackendEvents;
@@ -38,7 +37,7 @@ impl Router {
     pub fn forward_by_session_id(&self, session_id: SessionId, ev: ClientEvents) {
         if let Some(events_in) = self.sessions.get(&session_id) {
             if let Err(e) = events_in.send(ev.clone()) {
-                println!(
+                error!(
                     "😗 {} {:<8} {:<8} forwarding event by session ID {}",
                     "", "", "ERROR", e
                 )
@@ -49,7 +48,7 @@ impl Router {
     pub fn forward_by_client_id(&self, client_id: ClientId, ev: ClientEvents) {
         if let Some(session_sender) = self.client_sessions.get(&client_id) {
             if let Err(e) = session_sender.events_in.send(ev.clone()) {
-                println!(
+                error!(
                     "😗 {} {:<8} {:<8} forwarding event by client ID {}",
                     short_uuid(client_id),
                     "",
@@ -58,7 +57,7 @@ impl Router {
                 )
             }
         } else {
-            println!("Could not forward to client ID, perhaps it was already cleaned up ?")
+            error!("Could not forward to client ID, perhaps it was already cleaned up ?")
         }
     }
 
@@ -72,7 +71,7 @@ impl Router {
             {
                 for s in sessions {
                     if let Err(err) = s.events_in.send(ev.clone()) {
-                        println!(
+                        error!(
                             "😑 {} {} {:<8} forwarding event by game ID {}",
                             &crate::EMPTY_SHORT_UUID,
                             short_uuid(*gid),
@@ -81,6 +80,8 @@ impl Router {
                         )
                     }
                 }
+            } else {
+                info!("NO GAME SESSIONS for {:?}", ev); // todo
             }
         }
     }
@@ -137,7 +138,6 @@ impl Router {
             }
         }
     }
- 
     fn reconnect(
         &mut self,
         session_id: SessionId,
@@ -198,7 +198,7 @@ impl Router {
 
                 self.last_cleanup = Instant::now();
                 if count > 0 {
-                    println!(
+                    info!(
                         "🗑 {} {}  {:<8} {:<4} game records",
                         EMPTY_SHORT_UUID, EMPTY_SHORT_UUID, "CLEANUP", count
                     )
@@ -238,7 +238,7 @@ impl Router {
 /// it must respond to requests to add and drop listeners
 pub fn start(
     router_commands_out: Receiver<RouterCommand>,
-    kafka_events_out: Receiver<BackendEvents>,
+    backend_events_out: Receiver<BackendEvents>,
     idle_resp_out: Receiver<IdleStatusResponse>,
 ) {
     thread::spawn(move || {
@@ -263,7 +263,7 @@ pub fn start(
                             let event_clone = session_sender.events_in.clone();
                             router.reconnect(client_id, game_id, event_clone.clone());
                             if let Err(err) = event_clone.send(ClientEvents::Reconnected(ReconnectedEvent{game_id, reply_to: req_id, event_id: Uuid::new_v4(), player_up: router.playerup(game_id)})) {
-                                println!(
+                                error!(
                                     "😦 {} {} {:<8} could not send reconnect reply {}",
                                     short_uuid(client_id),
                                     short_uuid(game_id),
@@ -281,7 +281,7 @@ pub fn start(
                             for game_session in sessions {
                                 if game_session.session_id != session_id {
                                     if let Err(e) = game_session.events_in.send(ClientEvents::OpponentQuit) {
-                                        println!("failed to pass along Opponent Quit : {}", e)
+                                        error!("failed to pass along Opponent Quit : {}", e)
                                     }
                                 }
                             }
@@ -289,11 +289,14 @@ pub fn start(
 
                         router.game_sessions.remove(&game_id);
                     },
+                    Ok(RouterCommand::RouteGame { session_id, game_id }) =>
+                        router.route_new_game(session_id, game_id),
                     Err(e) => panic!("Unable to receive command via router channel: {:?}", e),
                 },
-            recv(kafka_events_out) -> event =>
+            recv(backend_events_out) -> event =>
                 match event {
                     Ok(BackendEvents::MoveMade(m)) => {
+                        info!("Routing backend event {:?}",m);
                         let u = m.clone();
                         router.set_playerup(u.game_id, u.player.other());
                         router.forward_by_game_id(BackendEvents::MoveMade(m).to_client_event())
@@ -321,6 +324,8 @@ pub fn start(
                         router.forward_by_session_id(white, ClientEvents::YourColor(YourColorEvent{game_id, your_color: Player::WHITE}));
                     },
                     Ok(e) => {
+                        info!("Routing Catch-all {:?}",e);
+
                         router.observe_game(e.game_id());
 
                         router.forward_by_game_id(e.to_client_event())
@@ -331,7 +336,7 @@ pub fn start(
             recv(idle_resp_out) -> idle_status_response => if let Ok(IdleStatusResponse(client_id, status)) = idle_status_response {
                 router.forward_by_client_id(client_id, ClientEvents::IdleStatusProvided(status))
             } else {
-                println!("router error reading idle response")
+                error!("router error reading idle response")
             }}
         }
     });
@@ -393,6 +398,10 @@ pub enum RouterCommand {
         client_id: ClientId,
     },
     QuitGame {
+        session_id: SessionId,
+        game_id: GameId,
+    },
+    RouteGame {
         session_id: SessionId,
         game_id: GameId,
     },

--- a/gateway/src/topics.rs
+++ b/gateway/src/topics.rs
@@ -15,6 +15,9 @@ pub const COLORS_CHOSEN_TOPIC: &str = "bugout-colors-chosen-ev";
 pub const CLIENT_HEARTBEAT_TOPIC: &str = "bugout-client-heartbeat-ev";
 pub const SESSION_DISCONNECTED_TOPIC: &str = "bugout-session-disconnected-ev";
 
+pub const ATTACH_BOT_TOPIC: &str = "bugout-attach-bot-cmd";
+pub const BOT_ATTACHED_TOPIC: &str = "bugout-bot-attached-ev";
+
 pub const SHUTDOWN_TOPIC: &str = "bugout-shutdown-ev";
 
 pub const CONSUME_TOPICS: &[&str] = &[

--- a/gateway/src/wakeup.rs
+++ b/gateway/src/wakeup.rs
@@ -1,4 +1,5 @@
 use crate::redis_io::RedisPool;
+use log::info;
 use r2d2_redis::redis;
 use redis::Commands;
 use serde_derive::{Deserialize, Serialize};
@@ -31,7 +32,7 @@ impl RedisWakeup {
         );
 
         p.map(|_| {
-            println!(
+            info!(
                 "☀️  {} {:<8} WAKEUP",
                 short_uuid(client_id),
                 EMPTY_SHORT_UUID

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -384,23 +384,19 @@ impl Handler for WsSession {
                     error!("failed to send RouteGame command {:?}", e)
                 }
 
-                Ok(
-                    {
-                        let payload = BackendCommands::AttachBot(
-                            micro_model_bot::gateway::AttachBot {
-                                game_id: micro_model_moves::GameId(game_id),
-                                player,
-                                board_size,
-                            }
-                        );
-                        
-                        if let Err(e) = self.session_commands_in.send(payload) {
-                            error!("could not set up bot backend {:?}", e)
-                        }
+                Ok({
+                    let payload = BackendCommands::AttachBot(micro_model_bot::gateway::AttachBot {
+                        game_id: micro_model_moves::GameId(game_id),
+                        player,
+                        board_size,
+                    });
 
-                        self.current_game = Some(game_id);
+                    if let Err(e) = self.session_commands_in.send(payload) {
+                        error!("could not set up bot backend {:?}", e)
                     }
-                )
+
+                    self.current_game = Some(game_id);
+                })
             }
             Err(_err) => {
                 error!(


### PR DESCRIPTION
This change set adds a gateway websocket binding to the `AttachBot` command, which is used when Sabaki declares that it wants to play against a given color opponent on a given board size.

It changes various `println!` invocations to `log` calls.

Advances #67. 