### PR TITLE
Optimize docker files for build cache

### DIFF
--- a/bugle/Dockerfile
+++ b/bugle/Dockerfile
@@ -1,8 +1,8 @@
 FROM rust
 
-WORKDIR /var/BUGOUT/bugle
-
 RUN rustup default stable  
+
+WORKDIR /var/BUGOUT/bugle
 
 COPY . /var/BUGOUT/bugle/.
 

--- a/micro-changelog/Dockerfile
+++ b/micro-changelog/Dockerfile
@@ -1,8 +1,8 @@
 FROM rust
 
-WORKDIR /var/BUGOUT/micro-changelog
-
 RUN rustup default stable  
+
+WORKDIR /var/BUGOUT/micro-changelog
 
 COPY . /var/BUGOUT/micro-changelog/.
 

--- a/micro-judge/Dockerfile
+++ b/micro-judge/Dockerfile
@@ -1,8 +1,8 @@
 FROM rust
 
-WORKDIR /var/BUGOUT/micro-judge
-
 RUN rustup default stable  
+
+WORKDIR /var/BUGOUT/micro-judge
 
 COPY . /var/BUGOUT/micro-judge/.
 


### PR DESCRIPTION
Make use of shared `RUN rustup default stable`