### PR TITLE
Fix redis streams versions

### DIFF
--- a/botlink/Cargo.lock
+++ b/botlink/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "botlink"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.12.1",
  "bincode",
@@ -919,9 +919,10 @@ dependencies = [
 
 [[package]]
 name = "redis_streams"
-version = "0.1.0"
-source = "git+https://github.com/Terkwood/BUGOUT?branch=unstable#25b24170fc9d3ef1567ad65330f9ac2ec2158f7e"
+version = "0.2.0"
+source = "git+https://github.com/Terkwood/BUGOUT?rev=fdad420#fdad420a54f7c130c18954e4ce6b11be1ed9b486"
 dependencies = [
+ "redis_conn_pool",
  "uuid",
 ]
 

--- a/botlink/Cargo.toml
+++ b/botlink/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.5"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 tungstenite = "0.10.1"
 micro_model_bot = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }

--- a/botlink/Cargo.toml
+++ b/botlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botlink"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 
@@ -11,7 +11,7 @@ tungstenite = "0.10.1"
 micro_model_bot = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
 micro_model_moves =  { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
 bincode = "1.2.1"
-redis_streams = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
+redis_streams = { git = "https://github.com/Terkwood/BUGOUT", rev = "fdad420", version = "0.2.0" }
 redis_conn_pool = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
 crossbeam = "0.7.3"
 crossbeam-channel = "0.4.2"

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "redis_streams"
 version = "0.2.0"
-source = "git+https://github.com/Terkwood/BUGOUT?branch=unstable#89b6755a4e30f2f28521217eee4e72ebe9aadafc"
+source = "git+https://github.com/Terkwood/BUGOUT?rev=fdad420#fdad420a54f7c130c18954e4ce6b11be1ed9b486"
 dependencies = [
  "redis_conn_pool",
  "uuid",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "gateway"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
 micro_model_moves = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
 micro_model_bot = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
-redis_streams = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
+redis_streams = { git = "https://github.com/Terkwood/BUGOUT", version = "0.2.0", rev = "fdad420" }
 chrono = { version = "0.4.10", features = ["serde"] }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 crossbeam = "0.7.3"

--- a/micro-changelog/Cargo.lock
+++ b/micro-changelog/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "micro_changelog"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "env_logger",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "redis_streams"
 version = "0.2.0"
-source = "git+https://github.com/Terkwood/BUGOUT?branch=fix/dedupe-entry-ids#a8f2bdbd8de11fe4cde82787cfa99a7f59e1ce7c"
+source = "git+https://github.com/Terkwood/BUGOUT?rev=fdad420#fdad420a54f7c130c18954e4ce6b11be1ed9b486"
 dependencies = [
  "redis_conn_pool",
  "uuid",

--- a/micro-changelog/Cargo.toml
+++ b/micro-changelog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro_changelog"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 micro_model_moves = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
 redis_conn_pool = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
-redis_streams = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
+redis_streams = { git = "https://github.com/Terkwood/BUGOUT", version = "0.2.0", rev = "fdad420" }
 bincode = "1.2.1"
 uuid = { version = "0.8.1", features = ["serde"] }
 log = "0.4.8"

--- a/micro-judge/Cargo.lock
+++ b/micro-judge/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "redis_streams"
 version = "0.2.0"
-source = "git+https://github.com/Terkwood/BUGOUT?branch=unstable#89b6755a4e30f2f28521217eee4e72ebe9aadafc"
+source = "git+https://github.com/Terkwood/BUGOUT?rev=fdad420#fdad420a54f7c130c18954e4ce6b11be1ed9b486"
 dependencies = [
  "redis_conn_pool",
  "uuid",

--- a/micro-judge/Cargo.lock
+++ b/micro-judge/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "micro_judge"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bincode",
  "env_logger",

--- a/micro-judge/Cargo.toml
+++ b/micro-judge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro_judge"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 
@@ -9,6 +9,6 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 bincode = "1.2.1"
 micro_model_moves = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
 redis_conn_pool = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
-redis_streams = {git = "https://github.com/Terkwood/BUGOUT", branch = "unstable"}
+redis_streams = { git = "https://github.com/Terkwood/BUGOUT", version = "0.2.0", branch = "unstable" }
 env_logger = "0.7.1"
 log = "0.4.8"

--- a/micro-judge/Cargo.toml
+++ b/micro-judge/Cargo.toml
@@ -9,6 +9,6 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 bincode = "1.2.1"
 micro_model_moves = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
 redis_conn_pool = { git = "https://github.com/Terkwood/BUGOUT", branch = "unstable" }
-redis_streams = { git = "https://github.com/Terkwood/BUGOUT", version = "0.2.0", branch = "unstable" }
+redis_streams = { git = "https://github.com/Terkwood/BUGOUT", version = "0.2.0", rev = "fdad420" }
 env_logger = "0.7.1"
 log = "0.4.8"


### PR DESCRIPTION
Sets the redis streams dependency to the current revision on `unstable` branch.  This effectively pins all the existing services to our local redis_streams 0.2.0 version.  Since we're using a monorepo, this semi-ugly hack seems like the most trustworthy approach.  

The redis_streams version on `unstable` branch can be advanced to 0.3.0 once this change set is merged, which will then allow #184 to be completed.

In terms of program functionality, there aren't actually any changes here.