### PR TITLE
Improve tinybrain systemd script and example

### DIFF
--- a/tinybrain/start-tinybrain.sh
+++ b/tinybrain/start-tinybrain.sh
@@ -8,6 +8,14 @@ then
 	exit 1
 fi
 
+if [ -z "$TINYBRAIN_BIN" ]
+then
+	echo "Please specify TINYBRAIN_BIN (parent folder of executable) in env"
+	exit 1
+fi
+
+export PATH="$PATH:$TINYBRAIN_BIN"
+
 # sorry, but we want to give the network additional
 # time to sort itself out.
 sleep 20 
@@ -15,4 +23,4 @@ sleep 20
 # move to a location where we expect a .env
 # file and a compiled katago executable
 cd $TINYBRAIN_HOME
-target/release/tinybrain
+tinybrain

--- a/tinybrain/tinybrain.service
+++ b/tinybrain/tinybrain.service
@@ -3,6 +3,7 @@ Description=BUGOUT tinybrain
 
 [Service]
 Environment="TINYBRAIN_HOME=/path/to/git/BUGOUT/tinybrain"
+Environment="TINYBRAIN_BIN=/home/__YOURUSER__/.cargo/bin"
 ExecStart=/bin/bash /path/to/git/BUGOUT/tinybrain/start-tinybrain.sh
 
 [Install]


### PR DESCRIPTION
Separates bin directory from the directory which expects the `.env` configuration, so that you can just use `cargo install` instead of relying on the `target/release` dir.