### PR TITLE
Admin script: cleanup dev env

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,0 +1,1 @@
+KEY_NAME=

--- a/admin/cleanup-amis.ts
+++ b/admin/cleanup-amis.ts
@@ -9,11 +9,11 @@
 // Per https://terkwood.farm/tech/aws_cli.html#destroy-your-amis-and-their-snapshots,
 // we want to provide auto-cleanup for all images and snapshots.
 
-import { runOrExit, parseProcessOutput } from "./procs.ts";
+import { runOrExit, parseProcessOutput, awsEc2Cmd } from "./procs.ts";
 
 const idp = await runOrExit(
   {
-    cmd: ["/usr/bin/aws", "ec2", "describe-images", "--owners", "self"],
+    cmd: awsEc2Cmd("describe-images --owners self"),
     stdout: "piped",
   },
 );
@@ -23,7 +23,7 @@ const { Images } = await parseProcessOutput(idp);
 for (let { ImageId } of Images) {
   await runOrExit(
     {
-      cmd: ["/usr/bin/aws", "ec2", "deregister-image", "--image-id", ImageId],
+      cmd: awsEc2Cmd(`deregister-image --image-id ${ImageId}`),
       stdout: undefined,
     },
   );
@@ -31,7 +31,7 @@ for (let { ImageId } of Images) {
 
 const dsp = await runOrExit(
   {
-    cmd: ["/usr/bin/aws", "ec2", "describe-snapshots", "--owner", "self"],
+    cmd: awsEc2Cmd("describe-snapshots --owner self"),
     stdout: "piped",
   },
 );
@@ -41,13 +41,7 @@ const { Snapshots } = await parseProcessOutput(dsp);
 for (let { SnapshotId } of Snapshots) {
   await runOrExit(
     {
-      cmd: [
-        "/usr/bin/aws",
-        "ec2",
-        "delete-snapshot",
-        "--snapshot-id",
-        SnapshotId,
-      ],
+      cmd: awsEc2Cmd(`delete-snapshot --snapshot-id ${SnapshotId}`),
       stdout: undefined,
     },
   );

--- a/admin/cleanup-amis.ts
+++ b/admin/cleanup-amis.ts
@@ -9,64 +9,47 @@
 // Per https://terkwood.farm/tech/aws_cli.html#destroy-your-amis-and-their-snapshots,
 // we want to provide auto-cleanup for all images and snapshots.
 
-//
-// Helper Functions
-//
-
-/** This side-effecting procedure will cause the program to quit 
- * if the subprocess returns a non-zero code.
- */
-const runOrExit = async (
-  cmd: string[],
-  stdout: number | "piped" | "inherit" | "null" | undefined,
-) => {
-  const p = Deno.run({
-    cmd,
-    stdout,
-  });
-
-  const { code } = await p.status();
-
-  if (code !== 0) {
-    const rawError = await p.stderrOutput();
-    const errorString = new TextDecoder().decode(rawError);
-    console.log(errorString);
-    Deno.exit(code);
-  }
-
-  return p;
-};
-
-const parseProcessOutput = async (p: Deno.Process) =>
-  JSON.parse(new TextDecoder().decode(await p.output()));
-
-// Primary Program
+import { runOrExit, parseProcessOutput } from "./procs.ts";
 
 const idp = await runOrExit(
-  ["/usr/bin/aws", "ec2", "describe-images", "--owners", "self"],
-  "piped",
+  {
+    cmd: ["/usr/bin/aws", "ec2", "describe-images", "--owners", "self"],
+    stdout: "piped",
+  },
 );
 
 const { Images } = await parseProcessOutput(idp);
 
 for (let { ImageId } of Images) {
   await runOrExit(
-    ["/usr/bin/aws", "ec2", "deregister-image", "--image-id", ImageId],
-    undefined,
+    {
+      cmd: ["/usr/bin/aws", "ec2", "deregister-image", "--image-id", ImageId],
+      stdout: undefined,
+    },
   );
 }
 
 const dsp = await runOrExit(
-  ["/usr/bin/aws", "ec2", "describe-snapshots", "--owner", "self"],
-  "piped",
+  {
+    cmd: ["/usr/bin/aws", "ec2", "describe-snapshots", "--owner", "self"],
+    stdout: "piped",
+  },
 );
 
 const { Snapshots } = await parseProcessOutput(dsp);
 
 for (let { SnapshotId } of Snapshots) {
   await runOrExit(
-    ["/usr/bin/aws", "ec2", "delete-snapshot", "--snapshot-id", SnapshotId],
-    undefined,
+    {
+      cmd: [
+        "/usr/bin/aws",
+        "ec2",
+        "delete-snapshot",
+        "--snapshot-id",
+        SnapshotId,
+      ],
+      stdout: undefined,
+    },
   );
 }
 

--- a/admin/cleanup-amis.ts
+++ b/admin/cleanup-amis.ts
@@ -11,40 +11,32 @@
 
 import { runOrExit, parseProcessOutput, awsEc2Cmd } from "./procs.ts";
 
-const idp = await runOrExit(
-  {
-    cmd: awsEc2Cmd("describe-images --owners self"),
-    stdout: "piped",
-  },
-);
+const idp = await runOrExit({
+  cmd: awsEc2Cmd("describe-images --owners self"),
+  stdout: "piped",
+});
 
 const { Images } = await parseProcessOutput(idp);
 
 for (let { ImageId } of Images) {
-  await runOrExit(
-    {
-      cmd: awsEc2Cmd(`deregister-image --image-id ${ImageId}`),
-      stdout: undefined,
-    },
-  );
+  await runOrExit({
+    cmd: awsEc2Cmd(`deregister-image --image-id ${ImageId}`),
+    stdout: undefined,
+  });
 }
 
-const dsp = await runOrExit(
-  {
-    cmd: awsEc2Cmd("describe-snapshots --owner self"),
-    stdout: "piped",
-  },
-);
+const dsp = await runOrExit({
+  cmd: awsEc2Cmd("describe-snapshots --owner self"),
+  stdout: "piped",
+});
 
 const { Snapshots } = await parseProcessOutput(dsp);
 
 for (let { SnapshotId } of Snapshots) {
-  await runOrExit(
-    {
-      cmd: awsEc2Cmd(`delete-snapshot --snapshot-id ${SnapshotId}`),
-      stdout: undefined,
-    },
-  );
+  await runOrExit({
+    cmd: awsEc2Cmd(`delete-snapshot --snapshot-id ${SnapshotId}`),
+    stdout: undefined,
+  });
 }
 
 Deno.exit(0);

--- a/admin/cleanup-dev-env.ts
+++ b/admin/cleanup-dev-env.ts
@@ -1,3 +1,15 @@
-#!/usr/bin/env -S deno --allow-run --allow-net
+#!/usr/bin/env -S deno run --allow-run --allow-net
 // SPDX-License-Identifier: MIT
-import { runOrExit, parseProcessOutput } from "./procs.ts";
+import { runOrExit, parseProcessOutput, awsEc2Cmd } from "./procs.ts";
+
+let described = await runOrExit(
+  { cmd: awsEc2Cmd("describe-instances"), stdout: "piped" },
+);
+
+const { Reservations } = await parseProcessOutput(described);
+
+for (let { Instances } of Reservations) {
+  for (let { InstanceId } of Instances) {
+    console.log(`Hello ${InstanceId}`);
+  }
+}

--- a/admin/cleanup-dev-env.ts
+++ b/admin/cleanup-dev-env.ts
@@ -12,7 +12,7 @@ let described = await runOrExit(
 const { Reservations } = await parseProcessOutput(described);
 
 for (let { Instances } of Reservations) {
-  for (let { InstanceId } of Instances) {
-    console.log(`Hello ${InstanceId}`);
+  for (let { InstanceId, KeyName } of Instances) {
+    console.log(`Hello ${InstanceId} ${KeyName}`);
   }
 }

--- a/admin/cleanup-dev-env.ts
+++ b/admin/cleanup-dev-env.ts
@@ -1,6 +1,9 @@
-#!/usr/bin/env -S deno run --allow-run --allow-net
+#!/usr/bin/env -S deno run --allow-run --allow-net --allow-read --allow-env
 // SPDX-License-Identifier: MIT
 import { runOrExit, parseProcessOutput, awsEc2Cmd } from "./procs.ts";
+import { config as loadDotEnv } from "https://deno.land/x/dotenv@v0.3.0/mod.ts";
+
+console.log(loadDotEnv({ safe: true }));
 
 let described = await runOrExit(
   { cmd: awsEc2Cmd("describe-instances"), stdout: "piped" },

--- a/admin/cleanup-dev-env.ts
+++ b/admin/cleanup-dev-env.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env -S deno --allow-run --allow-net
+// SPDX-License-Identifier: MIT
+import { runOrExit, parseProcessOutput } from "./procs.ts";

--- a/admin/cleanup-dev-env.ts
+++ b/admin/cleanup-dev-env.ts
@@ -64,3 +64,5 @@ if (instancesToTerminate.length > 0) {
     ),
   });
 }
+
+Deno.exit(0);

--- a/admin/cleanup-dev-env.ts
+++ b/admin/cleanup-dev-env.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env -S deno run --allow-run --allow-net --allow-read --allow-env
 // SPDX-License-Identifier: MIT
 import { runOrExit, parseProcessOutput, awsEc2Cmd } from "./procs.ts";
-import { config as loadDotEnv } from "https://deno.land/x/dotenv@v0.3.0/mod.ts";
+import { config as loadEnv } from "https://deno.land/x/dotenv@v0.3.0/mod.ts";
 
-console.log(loadDotEnv({ safe: true }));
+console.log(loadEnv({ safe: true, export: true }));
 
 const KEY_NAME = Deno.env.get("KEY_NAME");
+
+console.log(`Acting on ${KEY_NAME}`);
 
 let instsDescd = runOrExit(
   { cmd: awsEc2Cmd("describe-instances"), stdout: "piped" },
@@ -18,11 +20,14 @@ let addrsDescd = runOrExit(
 const { Reservations } = await parseProcessOutput(await instsDescd);
 
 console.log("Instances:");
+
+let instancesToTerminate = [];
 for (let { Instances } of Reservations) {
   for (let { InstanceId, KeyName } of Instances) {
-    console.log(`\t${InstanceId}`);
+    console.log(`\t${InstanceId} ${KeyName}`);
     if (KEY_NAME === KeyName) {
       console.log(`\t...Clean up on ${KeyName}`);
+      instancesToTerminate.push(InstanceId);
     }
   }
 }
@@ -30,8 +35,16 @@ for (let { Instances } of Reservations) {
 const { Addresses } = await parseProcessOutput(await addrsDescd);
 
 console.log("Addresses:");
+let addressesToRelease = [];
 for (let { InstanceId, AllocationId, AssociationId } of Addresses) {
   console.log(
     `\t${InstanceId} has alloc ${AllocationId} and assoc ${AssociationId}`,
   );
+  if (instancesToTerminate.includes(InstanceId)) {
+    addressesToRelease.push({ AllocationId, AssociationId });
+  }
 }
+
+console.log("\n");
+console.log(`Instances to terminate: ${JSON.stringify(instancesToTerminate)}`);
+console.log(`Addresses to release  : ${JSON.stringify(addressesToRelease)}`);

--- a/admin/cleanup-dev-env.ts
+++ b/admin/cleanup-dev-env.ts
@@ -5,14 +5,33 @@ import { config as loadDotEnv } from "https://deno.land/x/dotenv@v0.3.0/mod.ts";
 
 console.log(loadDotEnv({ safe: true }));
 
-let described = await runOrExit(
+const KEY_NAME = Deno.env.get("KEY_NAME");
+
+let instsDescd = runOrExit(
   { cmd: awsEc2Cmd("describe-instances"), stdout: "piped" },
 );
 
-const { Reservations } = await parseProcessOutput(described);
+let addrsDescd = runOrExit(
+  { cmd: awsEc2Cmd("describe-addresses"), stdout: "piped" },
+);
 
+const { Reservations } = await parseProcessOutput(await instsDescd);
+
+console.log("Instances:");
 for (let { Instances } of Reservations) {
   for (let { InstanceId, KeyName } of Instances) {
-    console.log(`Hello ${InstanceId} ${KeyName}`);
+    console.log(`\t${InstanceId}`);
+    if (KEY_NAME === KeyName) {
+      console.log(`\t...Clean up on ${KeyName}`);
+    }
   }
+}
+
+const { Addresses } = await parseProcessOutput(await addrsDescd);
+
+console.log("Addresses:");
+for (let { InstanceId, AllocationId, AssociationId } of Addresses) {
+  console.log(
+    `\t${InstanceId} has alloc ${AllocationId} and assoc ${AssociationId}`,
+  );
 }

--- a/admin/fcos/README.md
+++ b/admin/fcos/README.md
@@ -20,4 +20,4 @@ e.g. in [gateway-packer.json](gateway-packer.json):
     },
 ```
 
-What's more `rpm-ostreed` controls [automatic updates](https://docs.fedoraproject.org/en-US/iot/applying-updates-UG/#_automatic_updates) and needs to be disabled to prevent havoc during the `packer build` step.  You don't want the machine rebooting during your 79-hour `cargo install` step!
+What's more `rpm-ostreed` controls [automatic updates](https://docs.fedoraproject.org/en-US/iot/applying-updates-UG/#_automatic_updates) and needs to be disabled to prevent havoc during the `packer build` step. You don't want the machine rebooting during your 79-hour `cargo install` step!

--- a/admin/procs.ts
+++ b/admin/procs.ts
@@ -7,7 +7,7 @@ interface Runner {
   stdout?: number | "piped" | "inherit" | "null" | undefined;
 }
 
-/** This side-effecting procedure will cause the program to quit 
+/** This side-effecting procedure will cause the program to quit
  * if the subprocess returns a non-zero code.
  */
 const runOrExit = async ({ cmd, stdout }: Runner) => {

--- a/admin/procs.ts
+++ b/admin/procs.ts
@@ -1,6 +1,6 @@
-//
+// SPDX-License-Identifier: M
+
 // Process Helper Functions
-//
 
 interface Runner {
   cmd: string[];

--- a/admin/procs.ts
+++ b/admin/procs.ts
@@ -4,7 +4,7 @@
 
 interface Runner {
   cmd: string[];
-  stdout: number | "piped" | "inherit" | "null" | undefined;
+  stdout?: number | "piped" | "inherit" | "null" | undefined;
 }
 
 /** This side-effecting procedure will cause the program to quit 
@@ -15,7 +15,6 @@ const runOrExit = async ({ cmd, stdout }: Runner) => {
     cmd,
     stdout,
   });
-
   const { code } = await p.status();
 
   if (code !== 0) {
@@ -31,4 +30,15 @@ const runOrExit = async ({ cmd, stdout }: Runner) => {
 const parseProcessOutput = async (p: Deno.Process) =>
   JSON.parse(new TextDecoder().decode(await p.output()));
 
-export { runOrExit, parseProcessOutput };
+const awsEc2Cmd = (argStr: string) => {
+  let o = [];
+  o.push("/usr/bin/aws");
+  o.push("ec2");
+  for (let s of argStr.split(" ")) {
+    o.push(s);
+  }
+
+  return o;
+};
+
+export { runOrExit, parseProcessOutput, awsEc2Cmd };

--- a/admin/procs.ts
+++ b/admin/procs.ts
@@ -1,0 +1,34 @@
+//
+// Process Helper Functions
+//
+
+interface Runner {
+  cmd: string[];
+  stdout: number | "piped" | "inherit" | "null" | undefined;
+}
+
+/** This side-effecting procedure will cause the program to quit 
+ * if the subprocess returns a non-zero code.
+ */
+const runOrExit = async ({ cmd, stdout }: Runner) => {
+  const p = Deno.run({
+    cmd,
+    stdout,
+  });
+
+  const { code } = await p.status();
+
+  if (code !== 0) {
+    const rawError = await p.stderrOutput();
+    const errorString = new TextDecoder().decode(rawError);
+    console.log(errorString);
+    Deno.exit(code);
+  }
+
+  return p;
+};
+
+const parseProcessOutput = async (p: Deno.Process) =>
+  JSON.parse(new TextDecoder().decode(await p.output()));
+
+export { runOrExit, parseProcessOutput };

--- a/admin/procs.ts
+++ b/admin/procs.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: M
+// SPDX-License-Identifier: MIT
 
 // Process Helper Functions
 


### PR DESCRIPTION
Adds some administrative cleanup scripts to tear down instances, release elastic IP for gateway box, destroy packer-built snapshots & AMIs.