### PR TITLE
Use xgroup_create_mkstream

### DIFF
--- a/micro-changelog/Cargo.lock
+++ b/micro-changelog/Cargo.lock
@@ -409,7 +409,7 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "micro_changelog"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "env_logger",

--- a/micro-changelog/Cargo.toml
+++ b/micro-changelog/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "micro_changelog"
-version = "0.1.5"
+version = "0.1.6"
 
 [dependencies]
 bincode = "1.2.1"

--- a/micro-changelog/src/stream/messages.rs
+++ b/micro-changelog/src/stream/messages.rs
@@ -58,7 +58,6 @@ pub fn ack(
     Ok(())
 }
 
-
 fn deser(xread_result: XReadResult, topics: &StreamTopics) -> HashMap<XReadEntryId, StreamData> {
     let mut stream_data = HashMap::new();
     let move_accepted_topic = &topics.move_accepted_ev;

--- a/micro-changelog/src/stream/mod.rs
+++ b/micro-changelog/src/stream/mod.rs
@@ -173,14 +173,15 @@ fn xadd_game_states_changelog(
 
 pub fn create_consumer_group(topics: &StreamTopics, client: &redis::Client) {
     let mut conn = client.get_connection().expect("group create conn");
-    let mm: Result<(), _> = conn.xgroup_create(&topics.move_accepted_ev, GROUP_NAME, "$");
+    let mm: Result<(), _> = conn.xgroup_create_mkstream(&topics.move_accepted_ev, GROUP_NAME, "$");
     if let Err(e) = mm {
         warn!(
             "Ignoring error creating MoveAcceptedEv consumer group (it probably exists already) {:?}",
             e
         );
     }
-    let gs: Result<(), _> = conn.xgroup_create(&topics.game_states_changelog, GROUP_NAME, "$");
+    let gs: Result<(), _> =
+        conn.xgroup_create_mkstream(&topics.game_states_changelog, GROUP_NAME, "$");
     if let Err(e) = gs {
         warn!(
             "Ignoring error creating GameStates consumer group (it probably exists already) {:?}",

--- a/micro-judge/Cargo.lock
+++ b/micro-judge/Cargo.lock
@@ -427,7 +427,7 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "micro_judge"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "bincode",
  "env_logger",

--- a/micro-judge/Cargo.toml
+++ b/micro-judge/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "micro_judge"
-version = "0.1.12"
+version = "0.1.13"
 
 [dependencies]
 bincode = "1.2.1"

--- a/micro-judge/src/io/messages.rs
+++ b/micro-judge/src/io/messages.rs
@@ -1,3 +1,4 @@
+use super::stream::GROUP_NAME;
 use super::topics::*;
 use crate::model::*;
 use log::error;
@@ -25,7 +26,7 @@ pub fn read_sorted(
     let mut conn = client.get_connection().expect("redis conn");
     let opts = StreamReadOptions::default()
         .block(BLOCK_MS)
-        .group("micro-judge", "singleton");
+        .group(GROUP_NAME, "singleton");
     let ser = conn.xread_options(
         &[&topics.make_move_cmd, &topics.game_states_changelog],
         &[">", ">"],

--- a/micro-judge/src/io/stream.rs
+++ b/micro-judge/src/io/stream.rs
@@ -75,17 +75,18 @@ pub fn process(opts: StreamOpts) {
     }
 }
 
-const GROUP_NAME: &str = "micro-judge";
+pub const GROUP_NAME: &str = "micro-judge";
 pub fn create_consumer_groups(topics: &StreamTopics, client: &Client) {
     let mut conn = client.get_connection().expect("group create conn");
-    let mm: Result<(), _> = conn.xgroup_create(&topics.make_move_cmd, GROUP_NAME, "$");
+    let mm: Result<(), _> = conn.xgroup_create_mkstream(&topics.make_move_cmd, GROUP_NAME, "$");
     if let Err(e) = mm {
         warn!(
             "Ignoring error creating MakeMoveCmd consumer group (it probably exists already) {:?}",
             e
         );
     }
-    let gs: Result<(), _> = conn.xgroup_create(&topics.game_states_changelog, GROUP_NAME, "$");
+    let gs: Result<(), _> =
+        conn.xgroup_create_mkstream(&topics.game_states_changelog, GROUP_NAME, "$");
     if let Err(e) = gs {
         warn!(
             "Ignoring error creating GameStates consumer group (it probably exists already) {:?}",


### PR DESCRIPTION
Fixes the recent changes to micro-judge and micro-changelog so that they create the redis streams from which they'll later read, when creating consumer groups.  Without this, the services are throwing errors when they start up in dev environment.  Test didn't catch this since the streams had already existed in a local instance.