### PR TITLE
IO cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Match micro-sync make move payload to system (#352, #364)
 - Add log statements (#356)
 - Gateway: coordinate multiplayer events using redis streams (#332, #349, #350, #351, #353, #354, #355, #388, #394, #405)
-- Create shared model crates (#342, #339, #343, #344, #345, #346, #347, #348, #379, #380, #381, #382, #383, #384, #385, #386, #387)
+- Create shared model crates (#342, #339, #343, #344, #345, #346, #347, #348, #379, #380, #381, #382, #383, #384, #385, #386, #387, #407)
 - Create micro-sync (history provider) service (#331, #335, #337, #338)
 - Include session-disconnected stream in game-lobby reads (#359)
 - Fix memory leak in micro-changelog (#336)

--- a/botlink/Cargo.lock
+++ b/botlink/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "botlink"
-version = "0.2.0-a"
+version = "0.2.0-b"
 dependencies = [
  "base64 0.13.0",
  "bincode",

--- a/botlink/Cargo.toml
+++ b/botlink/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "botlink"
-version = "0.2.0-a"
+version = "0.2.0-b"
 
 [dependencies]
 base64 = "0.13.0"

--- a/botlink/src/stream/xread.rs
+++ b/botlink/src/stream/xread.rs
@@ -88,7 +88,7 @@ fn deser(xread_result: XReadResult) -> HashMap<XReadEntryId, StreamData> {
                                 warn!("Xread: Deser error around game states data")
                             }
                         } else {
-                            warn!("Fail XREAD")
+                            warn!("Fail XREAD {:?}", &v)
                         }
                     }
                 }

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.15.0-e"
+version = "0.15.0-f"
 dependencies = [
  "bincode",
  "chrono",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "gateway"
-version = "0.15.0-e"
+version = "0.15.0-f"
 
 [dependencies]
 bincode = "1.3.1"

--- a/gateway/src/redis_io/xread.rs
+++ b/gateway/src/redis_io/xread.rs
@@ -99,7 +99,7 @@ fn deser(xread_result: XReadResult) -> HashMap<XReadEntryId, StreamData> {
             } else if &xread_topic[..] == topics::MOVE_MADE_TOPIC {
                 for with_timestamps in xread_data {
                     for (k, v) in with_timestamps {
-                        let shape: Result<(String, Vec<u8>), _> = // game_id <uuid-str> data <bin>
+                        let shape: Result<(String, Vec<u8>), _> = // data <bin>
                             redis::FromRedisValue::from_redis_value(&v);
                         if let Ok(s) = shape {
                             if let (Ok(xid), Some(move_made)) = (

--- a/gateway/src/redis_io/xread.rs
+++ b/gateway/src/redis_io/xread.rs
@@ -101,13 +101,12 @@ fn deser(xread_result: XReadResult) -> HashMap<XReadEntryId, StreamData> {
             } else if &xread_topic[..] == topics::MOVE_MADE_TOPIC {
                 for with_timestamps in xread_data {
                     for (k, v) in with_timestamps {
-                        let shape: Result<(String, String, String, Vec<u8>), _> = // game_id <uuid-str> data <bin>
+                        let shape: Result<(String, Vec<u8>), _> = // game_id <uuid-str> data <bin>
                             redis::FromRedisValue::from_redis_value(&v);
                         if let Ok(s) = shape {
-                            if let (Ok(xid), Some(_game_id), Some(move_made)) = (
+                            if let (Ok(xid), Some(move_made)) = (
                                 XReadEntryId::from_str(k),
-                                Uuid::from_str(&s.1).ok(),
-                                bincode::deserialize::<move_model::MoveMade>(&s.3.clone()).ok(),
+                                bincode::deserialize::<move_model::MoveMade>(&s.1.clone()).ok(),
                             ) {
                                 stream_data.insert(xid, StreamData::MoveMade(move_made));
                             } else {

--- a/gateway/src/redis_io/xread.rs
+++ b/gateway/src/redis_io/xread.rs
@@ -6,9 +6,7 @@ use r2d2_redis::redis;
 use redis_streams::XReadEntryId;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
-use uuid::Uuid;
 
 /// performs a redis xread then sorts the results
 ///

--- a/micro-changelog/Cargo.lock
+++ b/micro-changelog/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "micro-changelog"
-version = "0.1.11"
+version = "0.2.0-a"
 dependencies = [
  "bincode",
  "core-model",

--- a/micro-changelog/Cargo.toml
+++ b/micro-changelog/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "micro-changelog"
-version = "0.1.11"
+version = "0.2.0-a"
 
 [dependencies]
 bincode = "1.3.1"
@@ -12,4 +12,4 @@ log = "0.4.11"
 move-model = {git = "https://github.com/Terkwood/BUGOUT", rev = "20e6620"}
 redis = {git = "https://github.com/mitsuhiko/redis-rs"}
 redis_streams = {git = "https://github.com/Terkwood/BUGOUT", version = "0.3.1", rev = "0e2fdb7"}
-uuid = { version = "0.8.1", features = ["serde"] }
+uuid = {version = "0.8.1", features = ["serde"]}

--- a/micro-changelog/src/stream/messages.rs
+++ b/micro-changelog/src/stream/messages.rs
@@ -12,8 +12,7 @@ pub enum StreamData {
     GS(GameState),
 }
 
-pub type XReadResult =
-    Vec<HashMap<String, Vec<HashMap<String, (String, Option<String>, String, Option<Vec<u8>>)>>>>;
+pub type XReadResult = Vec<HashMap<String, Vec<HashMap<String, (String, Option<Vec<u8>>)>>>>;
 
 const BLOCK_MS: usize = 5000;
 
@@ -67,7 +66,7 @@ fn deser(xread_result: XReadResult, topics: &StreamTopics) -> HashMap<XReadEntry
                     for (k, v) in with_timestamps {
                         if let (Ok(seq_no), Some(move_accepted)) = (
                             XReadEntryId::from_str(k),
-                            v.3.clone().and_then(|mm| {
+                            v.1.clone().and_then(|mm| {
                                 let move_made_deser: Option<MoveMade> =
                                     bincode::deserialize(&mm).ok();
                                 move_made_deser
@@ -84,7 +83,7 @@ fn deser(xread_result: XReadResult, topics: &StreamTopics) -> HashMap<XReadEntry
                     for (k, v) in with_timestamps {
                         if let (Ok(seq_no), Some(game_state)) = (
                             XReadEntryId::from_str(k),
-                            v.3.clone().and_then(|bytes| GameState::from(&bytes).ok()),
+                            v.1.clone().and_then(|bytes| GameState::from(&bytes).ok()),
                         ) {
                             stream_data.insert(seq_no, StreamData::GS(game_state));
                         } else {

--- a/micro-changelog/src/stream/mod.rs
+++ b/micro-changelog/src/stream/mod.rs
@@ -3,7 +3,6 @@ pub mod topics;
 
 use crate::repo::*;
 use crate::Components;
-use core_model::*;
 use messages::*;
 use move_model::*;
 use redis::Commands;
@@ -29,7 +28,6 @@ pub fn process(topics: StreamTopics, components: &crate::Components) {
                                 Ok(gs) => {
                                     // These next two ops are concurrent in the kafka impl
                                     if let Err(e) = xadd_game_states_changelog(
-                                        &move_acc.game_id,
                                         gs,
                                         &topics.game_states_changelog,
                                         components,
@@ -165,7 +163,6 @@ fn xadd_move_made(
 }
 
 fn xadd_game_states_changelog(
-    game_id: &GameId,
     gs: GameState,
     stream_name: &str,
     components: &Components,
@@ -177,8 +174,6 @@ fn xadd_game_states_changelog(
         .arg("~")
         .arg("1000")
         .arg("*")
-        .arg("game_id")
-        .arg(game_id.0.to_string())
         .arg("data")
         .arg(gs.serialize()?)
         .query::<String>(&mut conn)?)

--- a/micro-changelog/src/stream/mod.rs
+++ b/micro-changelog/src/stream/mod.rs
@@ -45,9 +45,9 @@ pub fn process(topics: StreamTopics, components: &crate::Components) {
                                 }
                             }
                         }
-                        (entry_id, StreamData::GS(game_id, gs)) => {
-                            info!("Stream: Game State {:?}", &game_id);
-                            if let Err(e) = game_states_repo::write(&game_id, &gs, &components) {
+                        (entry_id, StreamData::GS(gs)) => {
+                            info!("Stream: Game State {:?}", &gs.game_id);
+                            if let Err(e) = game_states_repo::write(&gs.game_id, &gs, &components) {
                                 error!("Error saving game state {:#?}", e)
                             }
 

--- a/micro-changelog/src/stream/mod.rs
+++ b/micro-changelog/src/stream/mod.rs
@@ -46,7 +46,7 @@ pub fn process(topics: StreamTopics, components: &crate::Components) {
                             }
                         }
                         (entry_id, StreamData::GS(gs)) => {
-                            info!("Stream: Game State {:?}", &gs.game_id);
+                            info!("Stream: Game State {:?}", &gs);
                             if let Err(e) = game_states_repo::write(&gs.game_id, &gs, &components) {
                                 error!("Error saving game state {:#?}", e)
                             }
@@ -122,7 +122,6 @@ fn update_game_state(
         orig
     })?;
     game_states_repo::write(&game_id, &new_game_state, &components)?;
-    info!("Updated {:?} {:?}", &game_id, &new_game_state);
     Ok(new_game_state)
 }
 
@@ -155,8 +154,6 @@ fn xadd_move_made(
         .arg("~")
         .arg("1000")
         .arg("*")
-        .arg("game_id")
-        .arg(mm.game_id.0.to_string())
         .arg("data")
         .arg(mm.serialize()?)
         .query::<String>(&mut conn)?)

--- a/micro-changelog/tests/integration.rs
+++ b/micro-changelog/tests/integration.rs
@@ -95,19 +95,17 @@ fn test_process_move() {
         .arg("STREAMS")
         .arg(GAME_STATES_TOPIC)
         .arg("0-0")
-        .query::<Vec<HashMap<String, Vec<HashMap<String, (String, String, String, Option<Vec<u8>>)>>>>>(&mut conn)
+        .query::<Vec<HashMap<String, Vec<HashMap<String, (String, Option<Vec<u8>>)>>>>>(&mut conn)
         .unwrap();
     assert_eq!(xread_game_states_changelog.len(), 1);
     let by_timestamp = xread_game_states_changelog[0].get(GAME_STATES_TOPIC);
     assert!(by_timestamp.is_some());
 
-    let game_state_payload_vec: Vec<(String, String, String, Option<Vec<u8>>)> =
+    let game_state_payload_vec: Vec<(String, Option<Vec<u8>>)> =
         by_timestamp.unwrap()[0].values().cloned().collect();
     let payload = &game_state_payload_vec[0];
-    assert_eq!(payload.0, "game_id");
-    assert_eq!(payload.1, game_id.0.to_string());
-    assert_eq!(payload.2, "data");
 
+    assert_eq!(payload.0, "data");
     let expected_game_state = GameState {
         game_id: game_id.clone(),
         board: Board {
@@ -120,7 +118,7 @@ fn test_process_move() {
         captures: Captures { black: 0, white: 0 },
     };
     assert_eq!(
-        bincode::deserialize::<GameState>(&payload.3.as_ref().unwrap()).unwrap(),
+        bincode::deserialize::<GameState>(&payload.1.as_ref().unwrap()).unwrap(),
         expected_game_state
     );
 

--- a/micro-judge/Cargo.lock
+++ b/micro-judge/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "micro-judge"
-version = "0.1.18"
+version = "0.2.0-a"
 dependencies = [
  "bincode",
  "core-model",

--- a/micro-judge/Cargo.toml
+++ b/micro-judge/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "micro-judge"
-version = "0.1.18"
+version = "0.2.0-a"
 
 [dependencies]
 bincode = "1.3.1"

--- a/micro-judge/src/io/stream.rs
+++ b/micro-judge/src/io/stream.rs
@@ -135,8 +135,6 @@ fn xadd_move_accepted(
         .arg("~")
         .arg("1000")
         .arg("*")
-        .arg("game_id")
-        .arg(move_made.game_id.0.to_string())
         .arg("data")
         .arg(move_made.serialize()?)
         .query::<String>(&mut conn)?)

--- a/micro-judge/tests/integration.rs
+++ b/micro-judge/tests/integration.rs
@@ -183,8 +183,6 @@ fn test_moves_processed() {
         .arg("~")
         .arg("1000")
         .arg("*")
-        .arg("game_id")
-        .arg(game_id.0.to_string())
         .arg("data")
         .arg(initial_game_state.serialize().unwrap())
         .query::<String>(&mut conn)
@@ -256,8 +254,6 @@ fn test_moves_processed() {
             .arg("~")
             .arg("1000")
             .arg("*")
-            .arg("game_id")
-            .arg(game_id.clone().0.to_string())
             .arg("data")
             .arg(current_game_state.serialize().unwrap())
             .query::<String>(&mut conn)
@@ -286,7 +282,7 @@ fn test_moves_processed() {
                     match c {
                         redis::Value::Bulk(ds) => match &ds[0] {
                             redis::Value::Bulk(es) => match &es[1] {
-                                redis::Value::Bulk(fs) => match &fs[3] {
+                                redis::Value::Bulk(fs) => match &fs[1] {
                                     redis::Value::Data(bin) => out.push(bin.clone()),
                                     _ => (),
                                 },


### PR DESCRIPTION
Fixes changelog to obey the expected shape of XADD for game-states-changelog. 

Fix micro-judge and gateway to use simplified payloads for movemade, moveaccepted.

Trivially adds some debugging to botlink.  

Cleanup originated from #174, #348.