### PR TITLE
Return to sanity with the docker-compose/.env story

### DIFF
--- a/botlink/Dockerfile
+++ b/botlink/Dockerfile
@@ -23,6 +23,8 @@ RUN apt install -y libssl-dev
 
 COPY --from=builder /usr/local/bin/botlink /usr/local/bin/botlink
 
+WORKDIR /BUGOUT
+
 ENV RUST_LOG info
 
 CMD ["botlink"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   gateway:
     build: gateway/.
     volumes:
-      - "./gateway/.env:/var/BUGOUT/gateway/.env:z"
+      - "./gateway/.env:/BUGOUT/.env:z"
     links:
       - "redis"
     depends_on:
@@ -57,7 +57,7 @@ services:
     depends_on:
       - "redis"
     volumes:
-      - "./botlink/.env:/var/BUGOUT/botlink/.env:z"
+      - "./botlink/.env:/BUGOUT/.env:z"
   reverse-proxy:
     image: abiosoft/caddy
     ports:

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -20,11 +20,7 @@ FROM debian:stable-slim
 
 COPY --from=builder /usr/local/bin/gateway /usr/local/bin/gateway
 
-WORKDIR /run-bugout
-
-# Hack to make sure env is _potentially_ copied (but not required)
-# https://stackoverflow.com/questions/31528384/conditional-copy-add-in-dockerfile
-COPY Cargo.toml .en[v] /run-bugout/
+WORKDIR /BUGOUT
 
 ENV RUST_LOG info
 


### PR DESCRIPTION
The previous changes where we used `COPY .env` were ill-advised.  We fixed the workdir/docker-compose setup to work again.