### PR TITLE
Fix botlink deserialization

### DIFF
--- a/botlink/Cargo.lock
+++ b/botlink/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "botlink"
-version = "1.0.0-c"
+version = "1.0.0-d"
 dependencies = [
  "base64 0.13.0",
  "bincode",

--- a/botlink/Cargo.toml
+++ b/botlink/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "botlink"
-version = "1.0.0-c"
+version = "1.0.0-d"
 
 [dependencies]
 base64 = "0.13.0"

--- a/botlink/bot-model/src/lib.rs
+++ b/botlink/bot-model/src/lib.rs
@@ -13,9 +13,17 @@ pub enum Difficulty {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AlphaNumCoord(pub char, pub u16);
 
-#[test]
-fn test_difficulty_json() {
-    let input = Difficulty::Max;
-    let json = serde_json::to_string(&input).expect("to_string");
-    assert_eq!(json, "\"Max\"")
+mod tests {
+    #[test]
+    fn test_difficulty_json() {
+        let input = Difficulty::Max;
+        let json = serde_json::to_string(&input).expect("to_string");
+        assert_eq!(json, "\"Max\"")
+    }
+
+    #[test]
+    fn test_difficulty_bincode() {
+        let input = Difficulty::Easy;
+        let bytes = bincode::serialize(&difficulty)?;
+    }
 }

--- a/botlink/bot-model/src/lib.rs
+++ b/botlink/bot-model/src/lib.rs
@@ -13,17 +13,9 @@ pub enum Difficulty {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AlphaNumCoord(pub char, pub u16);
 
-mod tests {
-    #[test]
-    fn test_difficulty_json() {
-        let input = Difficulty::Max;
-        let json = serde_json::to_string(&input).expect("to_string");
-        assert_eq!(json, "\"Max\"")
-    }
-
-    #[test]
-    fn test_difficulty_bincode() {
-        let input = Difficulty::Easy;
-        let bytes = bincode::serialize(&difficulty)?;
-    }
+#[test]
+fn test_difficulty_json() {
+    let input = Difficulty::Max;
+    let json = serde_json::to_string(&input).expect("to_string");
+    assert_eq!(json, "\"Max\"")
 }

--- a/botlink/src/repo/difficulty.rs
+++ b/botlink/src/repo/difficulty.rs
@@ -1,6 +1,7 @@
 use super::{expire, RepoErr};
 use bot_model::Difficulty;
 use core_model::GameId;
+use log::info;
 use redis::{Client, Commands};
 use std::sync::Arc;
 
@@ -14,11 +15,14 @@ impl DifficultyRepo for Arc<Client> {
         if let Ok(mut conn) = self.get_connection() {
             let bytes: Option<Vec<u8>> = conn.get(difficulty_key(&game_id))?;
             expire(&difficulty_key(game_id), &mut conn)?;
-            Ok(if let Some(b) = bytes {
+            let r = Ok(if let Some(b) = bytes {
                 bincode::deserialize(&b)?
             } else {
                 None
-            })
+            });
+
+            info!("Got difficulty: {:?}", r);
+            r
         } else {
             Err(RepoErr::Conn)
         }

--- a/botlink/src/repo/difficulty.rs
+++ b/botlink/src/repo/difficulty.rs
@@ -1,7 +1,6 @@
 use super::{expire, RepoErr};
 use bot_model::Difficulty;
 use core_model::GameId;
-use log::info;
 use redis::{Client, Commands};
 use std::sync::Arc;
 
@@ -21,16 +20,15 @@ impl DifficultyRepo for Arc<Client> {
                 if data.is_ok() {
                     expire(&key, &mut conn)?
                 }
-                let r = match data {
+
+                match data {
                     Ok(Some(bytes)) => {
                         let deser: Result<Difficulty, _> = bincode::deserialize(&bytes);
                         deser.map(|d| Some(d)).map_err(|e| RepoErr::SerDes(e))
                     }
                     Ok(None) => Ok(None),
                     Err(e) => Err(e),
-                };
-                info!("Got {:?}", r);
-                r
+                }
             }
             Err(e) => Err(RepoErr::Redis(e)),
         }

--- a/botlink/src/repo/difficulty.rs
+++ b/botlink/src/repo/difficulty.rs
@@ -12,31 +12,37 @@ pub trait DifficultyRepo: Send + Sync {
 
 impl DifficultyRepo for Arc<Client> {
     fn get(&self, game_id: &GameId) -> Result<Option<Difficulty>, RepoErr> {
-        if let Ok(mut conn) = self.get_connection() {
-            let bytes: Option<Vec<u8>> = conn.get(difficulty_key(&game_id))?;
-            expire(&difficulty_key(game_id), &mut conn)?;
-            let r = Ok(if let Some(b) = bytes {
-                bincode::deserialize(&b)?
-            } else {
-                None
-            });
+        match self.get_connection() {
+            Ok(mut conn) => {
+                let key = difficulty_key(game_id);
+                let data: Result<Option<Vec<u8>>, _> =
+                    conn.get(&key).map_err(|e| RepoErr::Redis(e));
 
-            info!("Got difficulty: {:?}", r);
-            r
-        } else {
-            Err(RepoErr::Conn)
+                if data.is_ok() {
+                    expire(&key, &mut conn)?
+                }
+                let r = match data {
+                    Ok(Some(bytes)) => {
+                        let deser: Result<Difficulty, _> = bincode::deserialize(&bytes);
+                        deser.map(|d| Some(d)).map_err(|e| RepoErr::SerDes(e))
+                    }
+                    Ok(None) => Ok(None),
+                    Err(e) => Err(e),
+                };
+                info!("Got {:?}", r);
+                r
+            }
+            Err(e) => Err(RepoErr::Redis(e)),
         }
     }
 
     fn put(&self, game_id: &GameId, difficulty: Difficulty) -> Result<(), RepoErr> {
-        if let Ok(mut conn) = self.get_connection() {
-            let bytes: Vec<u8> = bincode::serialize(&difficulty)?;
-            conn.set(difficulty_key(&game_id), bytes)?;
-            expire(&difficulty_key(game_id), &mut conn)?;
-            Ok(())
-        } else {
-            Err(RepoErr::Conn)
-        }
+        let key = difficulty_key(&game_id);
+        let mut conn = self.get_connection()?;
+        let bytes = bincode::serialize(&difficulty)?;
+        let done = conn.set(&key, bytes).map_err(|e| RepoErr::Redis(e))?;
+        expire(&key, &mut conn)?;
+        Ok(done)
     }
 }
 

--- a/botlink/src/stream/mod.rs
+++ b/botlink/src/stream/mod.rs
@@ -67,6 +67,15 @@ fn process_attach_bot(ab: &AttachBot, opts: &mut StreamOpts) {
             game_state.board.size = bs.into()
         }
 
+        if let Err(e) = opts.board_size_repo.put(&ab.game_id, game_state.board.size) {
+            error!("Failed to write board size {:?}", e)
+        }
+
+        info!("Put difficulty: {:?}", ab.difficulty);
+        if let Err(e) = opts.difficulty_repo.put(&ab.game_id, ab.difficulty) {
+            error!("Failed to put difficulty {:?}", e)
+        }
+
         if let Err(e) = opts.xadd.xadd_game_state(&game_state) {
             error!(
                 "Error writing redis stream for game state changelog : {:?}",
@@ -77,14 +86,6 @@ fn process_attach_bot(ab: &AttachBot, opts: &mut StreamOpts) {
             player: ab.player,
         }) {
             error!("Error xadd bot attached {:?}", e)
-        }
-
-        if let Err(e) = opts.board_size_repo.put(&ab.game_id, game_state.board.size) {
-            error!("Failed to write board size {:?}", e)
-        }
-
-        if let Err(e) = opts.difficulty_repo.put(&ab.game_id, ab.difficulty) {
-            error!("Failed to put difficulty {:?}", e)
         }
     }
 }

--- a/botlink/src/stream/mod.rs
+++ b/botlink/src/stream/mod.rs
@@ -71,7 +71,6 @@ fn process_attach_bot(ab: &AttachBot, opts: &mut StreamOpts) {
             error!("Failed to write board size {:?}", e)
         }
 
-        info!("Put difficulty: {:?}", ab.difficulty);
         if let Err(e) = opts.difficulty_repo.put(&ab.game_id, ab.difficulty) {
             error!("Failed to put difficulty {:?}", e)
         }


### PR DESCRIPTION
It was incorrectly reading e.g. `Some(Easy)` as `None`. Advances #322.