### PR TITLE
fix: expose mock for SortedStreams

### DIFF
--- a/micro-game-lobby/Cargo.lock
+++ b/micro-game-lobby/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "redis_streams"
 version = "1.0.0"
-source = "git+https://github.com/Terkwood/BUGOUT?rev=a1a0804#a1a0804a20dcd28c9c3dfad28ca5db6f88355f8b"
+source = "git+https://github.com/Terkwood/BUGOUT?rev=f8e4853#f8e4853c6a7202f0f899afe23004202f3bb59da9"
 dependencies = [
  "anyhow",
  "redis",

--- a/micro-game-lobby/Cargo.lock
+++ b/micro-game-lobby/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "move-model",
  "redis",
  "redis_streams",
+ "serde",
 ]
 
 [[package]]
@@ -430,7 +431,7 @@ dependencies = [
 [[package]]
 name = "redis_streams"
 version = "1.0.0"
-source = "git+https://github.com/Terkwood/BUGOUT?rev=a394d46#a394d4650faba1c834770d9213323617208c53ab"
+source = "git+https://github.com/Terkwood/BUGOUT?rev=a1a0804#a1a0804a20dcd28c9c3dfad28ca5db6f88355f8b"
 dependencies = [
  "anyhow",
  "redis",

--- a/micro-game-lobby/Cargo.toml
+++ b/micro-game-lobby/Cargo.toml
@@ -14,7 +14,7 @@ lobby-model = {path = "lobby-model"}
 log = "0.4.8"
 move-model = {git = "https://github.com/Terkwood/BUGOUT", rev = "20e6620"}
 redis = {version = "0.20.0", features = ["r2d2"]}
-redis_streams = {git = "https://github.com/Terkwood/BUGOUT", version = "1.0.0", rev = "a1a0804"}
+redis_streams = {git = "https://github.com/Terkwood/BUGOUT", version = "1.0.0", rev = "f8e4853"}
 
 [dev-dependencies]
 serde = "1.0.126"

--- a/micro-game-lobby/Cargo.toml
+++ b/micro-game-lobby/Cargo.toml
@@ -14,4 +14,7 @@ lobby-model = {path = "lobby-model"}
 log = "0.4.8"
 move-model = {git = "https://github.com/Terkwood/BUGOUT", rev = "20e6620"}
 redis = {version = "0.20.0", features = ["r2d2"]}
-redis_streams = {git = "https://github.com/Terkwood/BUGOUT", version = "1.0.0", rev = "a394d46"}
+redis_streams = {git = "https://github.com/Terkwood/BUGOUT", version = "1.0.0", rev = "a1a0804"}
+
+[dev-dependencies]
+serde = "1.0.126"

--- a/micro-game-lobby/src/main.rs
+++ b/micro-game-lobby/src/main.rs
@@ -13,7 +13,6 @@ fn main() {
 
     let lobby = stream::LobbyStreams::new(components);
 
-    let mut conn = client.get_connection().expect("redis conn");
     let stream_handlers: Vec<(&str, Box<dyn FnMut(XId, &Message) -> anyhow::Result<()>>)> = vec![
         (
             topics::FIND_PUBLIC_GAME,
@@ -32,8 +31,9 @@ fn main() {
             Box::new(|_xid, msg| lobby.consume_sd(msg)),
         ),
     ];
+
     let mut streams =
-        RedisSortedStreams::xgroup_create_mkstreams(stream_handlers, &stream::opts(), &mut conn)
+        RedisSortedStreams::xgroup_create_mkstreams(stream_handlers, &stream::opts(), client)
             .expect("stream creation");
 
     lobby.process(&mut streams)

--- a/micro-game-lobby/src/stream/mod.rs
+++ b/micro-game-lobby/src/stream/mod.rs
@@ -278,8 +278,6 @@ mod test {
         sorted_data: Arc<Mutex<Vec<(XId, StreamMessage)>>>,
     }
     impl XReadGroupSorted for FakeXRead {
-        /// Be careful, this implementation assumes
-        /// that the underlying data is pre-sorted
         fn read(
             &mut self,
             _stream_names: &[String],
@@ -331,11 +329,7 @@ mod test {
         thread::spawn(move || {
             let components = Components {
                 game_lobby_repo: Box::new(FakeGameLobbyRepo { contents: fgl }),
-                //xread: Box::new(FakeXRead {
-                //    sorted_data: sfs.clone(),
-                //}),
                 xadd: Box::new(FakeXAdd(xadd_in)),
-                //xack: Box::new(FakeXAck(xack_in)),
             };
             let lobby = LobbyStreams::new(components);
 
@@ -376,9 +370,6 @@ mod test {
         });
 
         // emit some events in a time-ordered fashion
-        // (we need to use time-ordered push since the
-        //   FakeXRead impl won't sort its underlying data )
-
         let mut fake_time_ms = 100;
         let incr_ms = 100;
 

--- a/micro-game-lobby/src/stream/mod.rs
+++ b/micro-game-lobby/src/stream/mod.rs
@@ -225,3 +225,239 @@ fn init_changelog(game_id: &GameId, board_size: u16, reg: &Components) {
         error!("could not write game state changelog {:?}", chgerr)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::components::Components;
+    use crate::repo::*;
+    use crossbeam_channel::{select, unbounded, Sender};
+    use redis_streams::anyhow;
+    use redis_streams::SortedStreamGuts;
+    use redis_streams::StreamHandler;
+    use redis_streams::StreamMessage;
+    use redis_streams::XAck;
+    use redis_streams::XId;
+    use redis_streams::XReadGroupSorted;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use std::thread;
+
+    struct FakeSortedStreams<F>
+    where
+        F: FnMut(XId, &Message) -> anyhow::Result<()>,
+    {
+        pub guts: SortedStreamGuts<F>,
+    }
+    impl<F> SortedStreams for FakeSortedStreams<F>
+    where
+        F: FnMut(XId, &Message) -> anyhow::Result<()>,
+    {
+        fn consume(&mut self) -> anyhow::Result<()> {
+            self.guts.consume()
+        }
+    }
+
+    struct FakeGameLobbyRepo {
+        pub contents: Arc<Mutex<GameLobby>>,
+    }
+
+    impl GameLobbyRepo for FakeGameLobbyRepo {
+        fn get(&self) -> Result<GameLobby, FetchErr> {
+            Ok(self.contents.lock().expect("mutex lock").clone())
+        }
+        fn put(&self, game_lobby: &GameLobby) -> Result<(), WriteErr> {
+            let mut data = self.contents.lock().expect("lock");
+            *data = game_lobby.clone();
+            Ok(())
+        }
+    }
+
+    struct FakeXRead {
+        sorted_data: Arc<Mutex<Vec<(XId, StreamMessage)>>>,
+    }
+    impl XReadGroupSorted for FakeXRead {
+        /// Be careful, this implementation assumes
+        /// that the underlying data is pre-sorted
+        fn read(
+            &mut self,
+            _stream_names: &[String],
+        ) -> anyhow::Result<Vec<(redis_streams::XId, StreamMessage)>> {
+            {
+                let mut data = self.sorted_data.lock().expect("lock");
+                if data.is_empty() {
+                    // stop the test thread from spinning like crazy
+                    std::thread::sleep(Duration::from_millis(1));
+                    Ok(vec![])
+                } else {
+                    let result = data.clone();
+                    *data = vec![];
+                    Ok(result)
+                }
+            }
+        }
+    }
+    struct FakeXAdd(Sender<StreamOutput>);
+    impl XAdd for FakeXAdd {
+        fn xadd(&self, data: StreamOutput) -> Result<(), XAddErr> {
+            if let Err(_) = self.0.send(data) {}
+            Ok(())
+        }
+    }
+
+    struct ItWasAcked;
+    struct FakeXAck(Sender<ItWasAcked>);
+    impl XAck for FakeXAck {
+        fn ack(&mut self, _stream_name: &str, _ids: &[String]) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+    #[test]
+    fn test_process() {
+        let (xadd_in, xadd_out) = unbounded();
+        let (xack_in, _) = unbounded();
+
+        let sorted_fake_stream = Arc::new(Mutex::new(vec![]));
+
+        let timeout = Duration::from_millis(160);
+
+        // set up a loop to process game lobby requests
+        let fake_game_lobby_contents = Arc::new(Mutex::new(GameLobby::default()));
+
+        let sfs = sorted_fake_stream.clone();
+        let fgl = fake_game_lobby_contents.clone();
+        use crate::topics;
+        thread::spawn(move || {
+            let components = Components {
+                game_lobby_repo: Box::new(FakeGameLobbyRepo { contents: fgl }),
+                //xread: Box::new(FakeXRead {
+                //    sorted_data: sfs.clone(),
+                //}),
+                xadd: Box::new(FakeXAdd(xadd_in)),
+                //xack: Box::new(FakeXAck(xack_in)),
+            };
+            let lobby = LobbyStreams::new(components);
+
+            let stream_handlers: Vec<(&str, Box<dyn FnMut(XId, &Message) -> anyhow::Result<()>>)> = vec![
+                (
+                    topics::FIND_PUBLIC_GAME,
+                    Box::new(|_xid, msg| lobby.consume_fpg(msg)),
+                ),
+                (
+                    topics::JOIN_PRIVATE_GAME,
+                    Box::new(|_xid, msg| lobby.consume_jpg(msg)),
+                ),
+                (
+                    topics::CREATE_GAME,
+                    Box::new(|_xid, msg| lobby.consume_cg(msg)),
+                ),
+                (
+                    topics::SESSION_DISCONNECTED,
+                    Box::new(|_xid, msg| lobby.consume_sd(msg)),
+                ),
+            ];
+
+            let mut handlers = HashMap::new();
+            for (stream, handler) in stream_handlers {
+                handlers.insert(stream.to_string(), StreamHandler::new(stream, handler));
+            }
+
+            let guts = SortedStreamGuts {
+                handlers,
+                xack: Box::new(FakeXAck(xack_in)),
+                xreadgroup_sorted: Box::new(FakeXRead {
+                    sorted_data: sfs.clone(),
+                }),
+            };
+            let mut streams = FakeSortedStreams { guts };
+
+            lobby.process(&mut streams)
+        });
+
+        // emit some events in a time-ordered fashion
+        // (we need to use time-ordered push since the
+        //   FakeXRead impl won't sort its underlying data )
+
+        let mut fake_time_ms = 100;
+        let incr_ms = 100;
+
+        let session_b = SessionId::new();
+        let session_w = SessionId::new();
+        let client_b = ClientId::new();
+        let client_w = ClientId::new();
+        let xid0 = quick_xid(fake_time_ms);
+        sorted_fake_stream.lock().expect("lock").push((
+            xid0,
+            StreamMessage(
+                topics::FIND_PUBLIC_GAME.to_string(),
+                to_message(FindPublicGame {
+                    client_id: client_w.clone(),
+                    session_id: session_w.clone(),
+                }),
+            ),
+        ));
+
+        thread::sleep(timeout);
+
+        // The game lobby repo should now contain one game
+        assert_eq!(
+            fake_game_lobby_contents
+                .clone()
+                .lock()
+                .expect("gl")
+                .games
+                .iter()
+                .collect::<Vec<_>>()
+                .len(),
+            1
+        );
+
+        // There should be an XADD triggered for a wait-for-opponent
+        // message
+        select! {
+            recv(xadd_out) -> msg => match msg {
+                Ok(StreamOutput::WFO(_)) => assert!(true),
+                _ => panic!("wrong output")
+            },
+            default(timeout) => panic!("WAIT timeout")
+        }
+
+        fake_time_ms += incr_ms;
+        sorted_fake_stream.lock().expect("lock").push((
+            quick_xid(fake_time_ms),
+            StreamMessage(
+                topics::FIND_PUBLIC_GAME.to_string(),
+                to_message(FindPublicGame {
+                    client_id: client_b,
+                    session_id: session_b,
+                }),
+            ),
+        ));
+
+        // There should now be GameReady in stream
+        select! {
+            recv(xadd_out) -> msg => match msg {
+                Ok(StreamOutput::GR(_)) => assert!(true),
+                _ => assert!(false)
+            },
+            default(timeout) => panic!("GR time out")
+        }
+    }
+
+    fn quick_xid(ms: u64) -> XId {
+        XId {
+            millis_time: ms,
+            seq_no: 0,
+        }
+    }
+
+    use serde;
+    use std::collections::HashMap;
+    fn to_message<T: serde::ser::Serialize>(v: T) -> redis_streams::Message {
+        let bin = bincode::serialize(&v).expect("ser");
+        let mut out = HashMap::new();
+        out.insert("data".to_string(), redis::Value::Data(bin));
+        out
+    }
+}

--- a/redis_streams/src/sorted_streams.rs
+++ b/redis_streams/src/sorted_streams.rs
@@ -2,7 +2,7 @@ use crate::*;
 use anyhow::Result;
 use redis::{
     streams::{StreamReadOptions, StreamReadReply},
-    Commands, Connection,
+    Commands,
 };
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -15,17 +15,19 @@ pub trait SortedStreams {
     fn consume(&mut self) -> Result<()>;
 }
 
-pub struct RedisSortedStreams<'a, F>
+use redis::Client;
+use std::rc::Rc;
+pub struct RedisSortedStreams<F>
 where
     F: FnMut(XId, &Message) -> Result<()>,
 {
-    pub handlers: HashMap<String, StreamHandler<F>>,
     pub group: Group,
     pub block_ms: usize,
-    pub redis: &'a mut Connection,
+    pub redis: Rc<Client>,
+    pub guts: SortedStreamGuts<F>,
 }
 
-impl<'a, F> RedisSortedStreams<'a, F>
+impl<F> RedisSortedStreams<F>
 where
     F: FnMut(XId, &Message) -> Result<()>,
 {
@@ -33,11 +35,12 @@ where
     pub fn xgroup_create_mkstreams(
         stream_handlers: Vec<(&str, F)>,
         opts: &ConsumerGroupOpts,
-        redis: &'a mut Connection,
+        redis: Rc<Client>,
     ) -> Result<Self> {
         let mut handlers = HashMap::new();
         for (stream, handler) in stream_handlers {
-            let _: Result<(), redis::RedisError> = match redis
+            let mut conn = redis.get_connection()?;
+            let _: Result<(), redis::RedisError> = match conn
                 .xgroup_create_mkstream(stream, &opts.group.group_name, "$")
                 .map(|_: redis::Value| ())
             {
@@ -53,40 +56,101 @@ where
             handlers.insert(stream.to_string(), StreamHandler::new(stream, handler));
         }
 
+        let block_ms = opts.block_ms;
+
+        let xrgs = Box::new(RedisXReadGroupSorted {
+            redis: redis.clone(),
+            group: opts.group.clone(),
+            block_ms,
+        });
+        let guts = SortedStreamGuts {
+            handlers,
+            xack: Box::new(RedisXAck {
+                redis: redis.clone(),
+                group: opts.group.clone(),
+            }),
+            xreadgroup_sorted: xrgs,
+        };
+
         Ok(Self {
             group: opts.group.clone(),
-            redis,
+            redis: redis.clone(),
             block_ms: opts.block_ms,
-            handlers,
+            guts: guts,
         })
     }
 }
 
-impl<'a, F> SortedStreams for RedisSortedStreams<'a, F>
+pub struct SortedStreamGuts<F>
+where
+    F: FnMut(XId, &Message) -> Result<()>,
+{
+    pub handlers: HashMap<String, StreamHandler<F>>,
+    pub xreadgroup_sorted: Box<dyn XReadGroupSorted>,
+    pub xack: Box<dyn XAck>,
+}
+
+pub trait XReadGroupSorted {
+    fn read(&mut self, stream_names: &[String]) -> Result<Vec<(XId, StreamMessage)>>;
+}
+pub trait XAck {
+    fn ack(&mut self, stream_name: &str, ids: &[String]) -> Result<()>;
+}
+
+struct RedisXReadGroupSorted {
+    pub group: Group,
+    pub block_ms: usize,
+    pub redis: Rc<Client>,
+}
+struct RedisXAck {
+    pub group: Group,
+    pub redis: Rc<Client>,
+}
+impl XAck for RedisXAck {
+    fn ack(&mut self, stream_name: &str, ids: &[String]) -> Result<()> {
+        self.redis
+            .get_connection()?
+            .xack(stream_name, &self.group.group_name, ids)
+            .map_err(|_| anyhow::Error::msg("xack"))
+    }
+}
+
+impl XReadGroupSorted for RedisXReadGroupSorted {
+    fn read(&mut self, stream_names: &[String]) -> Result<Vec<(XId, StreamMessage)>> {
+        Ok({
+            let mut out = Vec::with_capacity(50);
+            let opts = StreamReadOptions::default()
+                .block(self.block_ms)
+                .group(&self.group.group_name, &self.group.consumer_name);
+            let read_ops: Vec<String> = stream_names.iter().map(|_| READ_OP.to_string()).collect();
+
+            let mut redis = self.redis.get_connection()?;
+
+            let xrr: StreamReadReply = redis.xread_options(&stream_names, &read_ops, opts)?;
+            for k in xrr.keys {
+                let key = k.key;
+                for x in k.ids {
+                    let message: Message = x.map;
+                    if let Ok(xid) = XId::from_str(&x.id) {
+                        out.push((xid, StreamMessage(key.clone(), message)));
+                    }
+                }
+            }
+            out.sort_by_key(|t| t.0);
+            out
+        })
+    }
+}
+
+impl<F> SortedStreams for SortedStreamGuts<F>
 where
     F: FnMut(XId, &Message) -> Result<()>,
 {
     fn consume(&mut self) -> Result<()> {
         let mut unacked = Unacknowledged::default();
-        let opts = StreamReadOptions::default()
-            .block(self.block_ms)
-            .group(&self.group.group_name, &self.group.consumer_name);
         let stream_names: Vec<String> = self.handlers.keys().cloned().collect();
-        let read_ops: Vec<String> = stream_names.iter().map(|_| READ_OP.to_string()).collect();
 
-        let xrr: StreamReadReply = self.redis.xread_options(&stream_names, &read_ops, opts)?;
-        let mut by_time: Vec<(XId, StreamMessage)> = Vec::with_capacity(50);
-
-        for k in xrr.keys {
-            let key = k.key;
-            for x in k.ids {
-                if let Ok(xid) = XId::from_str(&x.id) {
-                    by_time.push((xid, StreamMessage(key.clone(), x.map)));
-                }
-            }
-        }
-
-        by_time.sort_by_key(|t| t.0);
+        let by_time: Vec<(XId, StreamMessage)> = self.xreadgroup_sorted.read(&stream_names)?;
 
         for (xid, StreamMessage(stream, message)) in by_time {
             if let Some(handler) = self.handlers.get_mut(&stream) {
@@ -99,16 +163,26 @@ where
 
         for (stream, xids) in unacked.0 {
             let ids: Vec<String> = xids.iter().map(|xid| xid.to_string()).collect();
-            self.redis.xack(&stream, &self.group.group_name, &ids)?
+            self.xack.ack(&stream, &ids)?
         }
 
         Ok(())
     }
 }
 
+impl<'a, F> SortedStreams for RedisSortedStreams<F>
+where
+    F: FnMut(XId, &Message) -> Result<()>,
+{
+    fn consume(&mut self) -> Result<()> {
+        self.guts.consume()
+    }
+}
+
 const READ_OP: &str = ">";
 
-struct StreamMessage(pub String, pub Message);
+#[derive(Clone)]
+pub struct StreamMessage(pub String, pub Message);
 
 /// Track unacknowledged messages by stream name
 struct Unacknowledged(pub HashMap<String, Vec<XId>>);


### PR DESCRIPTION
Exposes mock implementations for `SortedStreams` in the test configuration. 

Hacks the main sorted steams impl to use a Redis client instead of connection. 

Brings back the deleted game lobby unit test.  (Resolves #507.)